### PR TITLE
fix: set onLongPress event to open FloatingMenu to Image directly

### DIFF
--- a/src/pages/PersonalChat/ImageChatView/ImageView.tsx
+++ b/src/pages/PersonalChat/ImageChatView/ImageView.tsx
@@ -7,6 +7,7 @@ import LightboxHeader from './LightboxHeader'
 import getStyles from './styles'
 
 import { LightboxModal } from '@2060/components'
+import { useChat } from '@2060/hooks/agent'
 import { useTheme } from '@2060/hooks/providers/ThemeProvider'
 import { ChatEntryMessage } from '@2060/pages/PersonalChat/ChatMessage/Props'
 
@@ -19,32 +20,33 @@ type ImageView = {
 }
 
 const ImageView = memo((props: ImageView) => {
+  const { displayMessageFloatingMenu } = useChat()
   const [lightboxVisible, setLightboxVisible] = useState(false)
-  const { imagePreviewUri, imageUri, ...lightboxHeaderProps } = props
+  const { imagePreviewUri, imageUri, fileMediaInfo, currentMessage } = props
   const theme = useTheme()
   const styles = getStyles(theme)
 
-  const onToggleModalLightbox = (value: boolean) => {
-    setLightboxVisible(value)
-    StatusBar.setHidden(value)
+  const onToggleModalLightbox = () => {
+    const newIsLightboxVisible = !lightboxVisible
+    setLightboxVisible(newIsLightboxVisible)
+    StatusBar.setHidden(newIsLightboxVisible)
   }
+  const onLongPress = () => displayMessageFloatingMenu(currentMessage)
 
-  return (
-    <>
-      {lightboxVisible ? (
-        <LightboxModal
-          visible={lightboxVisible}
-          onCloseModal={() => onToggleModalLightbox(false)}
-          renderHeader={(close: () => void) => <LightboxHeader onBack={close} {...lightboxHeaderProps} />}
-        >
-          <Image source={{ uri: imageUri }} style={styles.imageLightbox} />
-        </LightboxModal>
-      ) : (
-        <TouchableOpacity onPress={() => onToggleModalLightbox(true)}>
-          <Image style={props.style} source={{ uri: imagePreviewUri }} />
-        </TouchableOpacity>
+  return lightboxVisible ? (
+    <LightboxModal
+      visible={lightboxVisible}
+      onCloseModal={onToggleModalLightbox}
+      renderHeader={(close: () => void) => (
+        <LightboxHeader fileMediaInfo={fileMediaInfo} onBack={close} currentMessage={currentMessage} />
       )}
-    </>
+    >
+      <Image source={{ uri: imageUri }} style={styles.imageLightbox} />
+    </LightboxModal>
+  ) : (
+    <TouchableOpacity onPress={onToggleModalLightbox} onLongPress={onLongPress}>
+      <Image style={props.style} source={{ uri: imagePreviewUri }} />
+    </TouchableOpacity>
   )
 })
 


### PR DESCRIPTION
set onLongPress event to open FloatingMenu directly due to event propagations conflict between nested TouchableOpacity