### PR TITLE
fix: add a timeout after backup build before fetch backup info

### DIFF
--- a/src/hooks/useBuildBackup.ts
+++ b/src/hooks/useBuildBackup.ts
@@ -89,6 +89,7 @@ export const useBuildBackup = ({
   }
 
   const onBackupUploadSuccess = async () => {
+    // Timeout is set to user sees in screen that backup progress reaches 100% done before update state
     setTimeout(() => {
       setUploadProgress({ ...backupProgressInitialValues, isUploadingBackup: false })
     }, 1000)

--- a/src/hooks/useICloud.ts
+++ b/src/hooks/useICloud.ts
@@ -105,8 +105,12 @@ export const useICloud = () => {
           onProgress(data) {
             setUploadProgress(prev => ({ ...prev, progress: data?.progress }))
             if (data?.progress === 100) {
-              getBackupInfo()
               onBackupUploadSuccess()
+              // Timeout is set because after finish backup upload process to icloud drive it takes
+              // a while to have metadata of file updated to fetch info of it again
+              setTimeout(() => {
+                getBackupInfo()
+              }, 1000)
             }
           },
         })


### PR DESCRIPTION
add a timeout after backup build before fetch backup info to give a while to icloud drive update its metadata and get info updated