### PR TITLE
fix: NfcAdapter crash when exiting app in Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "react-native-cloud-store": "0.11.0",
     "react-native-config": "^1.5.1",
     "react-native-create-thumbnail": "^2.0.0",
-    "react-native-eid-reader": "npm:@2060.io/react-native-eid-reader@0.0.1-alpha.10",
+    "react-native-eid-reader": "npm:@2060.io/react-native-eid-reader@0.0.1-alpha.11",
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "^2.12.1",
     "react-native-get-random-values": "^1.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11031,7 +11031,7 @@ __metadata:
     react-native-cloud-store: 0.11.0
     react-native-config: ^1.5.1
     react-native-create-thumbnail: ^2.0.0
-    react-native-eid-reader: "npm:@2060.io/react-native-eid-reader@0.0.1-alpha.10"
+    react-native-eid-reader: "npm:@2060.io/react-native-eid-reader@0.0.1-alpha.11"
     react-native-fs: ^2.20.0
     react-native-gesture-handler: ^2.12.1
     react-native-get-random-values: ^1.7.0
@@ -15933,13 +15933,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-eid-reader@npm:@2060.io/react-native-eid-reader@0.0.1-alpha.10":
-  version: 0.0.1-alpha.10
-  resolution: "@2060.io/react-native-eid-reader@npm:0.0.1-alpha.10"
+"react-native-eid-reader@npm:@2060.io/react-native-eid-reader@0.0.1-alpha.11":
+  version: 0.0.1-alpha.11
+  resolution: "@2060.io/react-native-eid-reader@npm:0.0.1-alpha.11"
   peerDependencies:
     react: "*"
     react-native: "*"
-  checksum: 3bd0e3f5e64c258084faf4253ae027e95e16d54559eab4a3564156f0b2ab5feac5fbb5985101055179f38a94c84adcd791b6dada6d9a7d0cbb5b36f957acf5fc
+  checksum: 06c6ac1fca433394f01adadd9c6a9a239b6efb63c8090f6105c618ccb1b1af4f5cf670d52de51cbea2d7e74df4c2e624097b774342da61243a87dcf044448bb3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Minor workaround in react-native-eid-reader to prevent app from throwing an error when exiting in certain test devices.