### PR TITLE
fix: remove use of android:roundIcon

### DIFF
--- a/android/app/src/dev/AndroidManifest.xml
+++ b/android/app/src/dev/AndroidManifest.xml
@@ -18,8 +18,7 @@
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher_foreground"
-      android:roundIcon="@mipmap/ic_launcher"
+      android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
       tools:replace="android:theme"
       android:theme="@style/Theme.App.Starting"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,8 +18,7 @@
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher_foreground"
-      android:roundIcon="@mipmap/ic_launcher"
+      android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
       tools:replace="android:theme"
       android:theme="@style/Theme.App.Starting"

--- a/android/app/src/staging/AndroidManifest.xml
+++ b/android/app/src/staging/AndroidManifest.xml
@@ -18,8 +18,7 @@
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher_foreground"
-      android:roundIcon="@mipmap/ic_launcher"
+      android:icon="@mipmap/ic_launcher"
       android:allowBackup="false"
       tools:replace="android:theme"
       android:theme="@style/Theme.App.Starting"


### PR DESCRIPTION
In Oppo A38 android 14 app icon was not displaying correctly. After, change looks good! Others devices like samsung, motorola continues looking well 
**Before**
![before](https://github.com/user-attachments/assets/5bc0f36e-833d-477b-a2e3-175306e83ae1)
**After**
![after](https://github.com/user-attachments/assets/5eeed8fe-feaa-4e81-bc69-55d0282a0aba)
