### PR TITLE
fix: add isActive to condition to render Camera Scan

### DIFF
--- a/src/components/CodeScanner/CodeScanner.tsx
+++ b/src/components/CodeScanner/CodeScanner.tsx
@@ -25,11 +25,11 @@ const SCREEN_HEIGHT = Platform.select<number>({
 
 interface Props {
   camera: React.MutableRefObject<Camera | null | undefined>
-  active: boolean
+  isActive: boolean
   onBarcodeScanned: (barcode: string) => void
 }
 
-const CodeScanner: React.FC<Props> = ({ camera, active, onBarcodeScanned }) => {
+const CodeScanner: React.FC<Props> = ({ camera, isActive, onBarcodeScanned }) => {
   const [cameraPermissionStatus, setCameraPermissionStatus] = useState<CameraPermissionStatus>()
   const devices = useCameraDevices()
   const device = devices.find(dev => dev.position === 'back')
@@ -41,7 +41,7 @@ const CodeScanner: React.FC<Props> = ({ camera, active, onBarcodeScanned }) => {
 
   useEffect(() => {
     setScannedCodes([])
-  }, [active])
+  }, [isActive])
 
   const codeScanner = useCodeScanner({
     codeTypes: ['qr'],
@@ -82,13 +82,13 @@ const CodeScanner: React.FC<Props> = ({ camera, active, onBarcodeScanned }) => {
 
   return (
     <React.Fragment>
-      {device !== undefined && hasPermission ? (
+      {device && isActive && hasPermission ? (
         <Camera
           style={{ height: screenHeight, zIndex: -1 }}
           ref={ref => (camera.current = ref)}
           device={device}
           format={format}
-          isActive={active}
+          isActive={isActive}
           onError={onError}
           fps={fps}
           codeScanner={codeScanner}

--- a/src/pages/Scan/Scan.tsx
+++ b/src/pages/Scan/Scan.tsx
@@ -156,7 +156,7 @@ const Scan = ({ navigation }: Props) => {
           {t('scan.textDescriptionScanner')}
         </Text>
       </View>
-      <CodeScanner camera={camera} active={isActive} onBarcodeScanned={processCode} />
+      <CodeScanner camera={camera} isActive={isActive} onBarcodeScanned={processCode} />
     </View>
   )
 


### PR DESCRIPTION
add isActive to condition to render Camera scan to avoid possible calls or scan results when already processed a code