### PR TITLE
feat: deployment to nexus for dev releases

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -208,7 +208,7 @@ jobs:
                                   <key>kind</key>
                                   <string>software-package</string>
                                   <key>url</key>
-                                  <string>https://nexus.dev.2060.io/repository/ios/hologram-app/$NEW_RELEASE_VERSION/app.ipa</string>
+                                  <string>https://$NEXUS_HOST/repository/ios/hologram-app/$NEW_RELEASE_VERSION/app.ipa</string>
                               </dict>
                           </array>
                           <key>metadata</key>


### PR DESCRIPTION
Initial attempt to add deployment to Nexus in dev CI/CD. Once it is working properly, we can get rid of App Center