### PR TITLE
fix: keep loader while is processing invitation from a deep link

### DIFF
--- a/src/pages/HomeMain/HomeMainContainer.tsx
+++ b/src/pages/HomeMain/HomeMainContainer.tsx
@@ -6,13 +6,13 @@ import { HomeTabProps } from './HomeMainProps'
 
 import { Loader } from '@2060/components/common'
 import { useMobileAgent } from '@2060/hooks/agent'
-import { DidcommInvitationType, processInvitation } from '@2060/services/agent'
+import { DidcommInvitationType, processInvitation as agentProcessInvitation } from '@2060/services/agent'
 import { logError } from '@2060/utils'
 import { toast } from '@2060/utils/toast'
 
 const HomeMainContainer = (HomeMainComponent: ElementType) => {
   const WrapperHomeMain = (props: HomeTabProps) => {
-    const [loading, setLoading] = useState(false)
+    const [isProcessingLink, setIsProcessingLink] = useState(false)
     const { agent } = useMobileAgent()
 
     const { navigation, route } = props
@@ -25,10 +25,11 @@ const HomeMainContainer = (HomeMainComponent: ElementType) => {
     }, [route.params])
 
     const goToConnectionDetails = (connectionId: string) => navigate('ConnectionDetails', { connectionId })
-    const goToInvitation = async (invitation: OutOfBandInvitation) => {
+
+    const processInvitation = async (invitation: OutOfBandInvitation) => {
       if (!agent) throw new Error('Agent not defined')
       try {
-        const { success, existingConnectionId, invitationType, recordId } = await processInvitation(
+        const { success, existingConnectionId, invitationType, recordId } = await agentProcessInvitation(
           agent,
           invitation,
         )
@@ -53,14 +54,16 @@ const HomeMainContainer = (HomeMainComponent: ElementType) => {
         }
       } catch (error) {
         toast({ type: 'error', message: `${error}` })
+        logError('Error processing invitation', error)
+      } finally {
+        setIsProcessingLink(false)
       }
     }
 
     const processDeepLink = async () => {
-      setLoading(true)
       try {
         if (!agent) throw new Error('Agent not created')
-
+        setIsProcessingLink(true)
         const [[parameterType, value]] = Object.entries(route.params!)
 
         let invitationUrl: string | undefined
@@ -72,12 +75,11 @@ const HomeMainContainer = (HomeMainComponent: ElementType) => {
         if (!invitationUrl) throw new Error('Invalid invitation URL')
 
         const invitation = await agent?.oob.parseInvitation(invitationUrl)
-        if (invitation) goToInvitation(invitation)
+        if (invitation) processInvitation(invitation)
       } catch (error) {
-        logError('Error processing deep link', error)
+        setIsProcessingLink(false)
         toast({ type: 'error', message: `${error}` })
-      } finally {
-        setLoading(false)
+        logError('Error processing deep link', error)
       }
     }
 
@@ -85,7 +87,7 @@ const HomeMainContainer = (HomeMainComponent: ElementType) => {
       if (isValidParams) processDeepLink()
     }, [route.params])
 
-    if (route.params && loading) return <Loader />
+    if (route.params && isProcessingLink) return <Loader />
 
     return <HomeMainComponent {...props} />
   }


### PR DESCRIPTION
keep loader indicator also when is processing invitation to avoid a possible dead time (no ui feedback to user) while this is being executed 
 
Motivation issue: https://github.com/2060-io/generic-verifier/issues/32