### PR TITLE
fix: move RefreshedAvatarsUrlsProvider above VideoCallProvider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,10 +57,10 @@ const ProvidersTree = buildProvidersTree([
   [NavigationProvider],
   [PushNotificationsProvider],
   [FileUploadDownloadProvider],
+  [RefreshedAvatarsUrlsProvider],
   [VideoCallProvider],
   [ScreenLockProvider],
   [SharedDataFromOtherAppsProvider],
-  [RefreshedAvatarsUrlsProvider],
 ])
 
 const App = () => {


### PR DESCRIPTION
move RefreshedAvatarsUrlsProvider above VideoCallProvider because in a video call we need access in Avatar to RefreshedAvatarsUrlsProvider