### PR TITLE
fix: call updateThreadIfNeeded in addReceiptToRelatedEntries

### DIFF
--- a/src/hooks/agent/chat/services/ChatEntryService.ts
+++ b/src/hooks/agent/chat/services/ChatEntryService.ts
@@ -169,8 +169,7 @@ export function addReceiptToRelatedEntries(realm: Realm, receipt: MessageReceipt
       if (!lastChatEntry || lastChatEntry?.createdAt < entry.createdAt) lastChatEntry = entry
     }
   })
-
-  return lastChatEntry
+  if (lastChatEntry) updateThreadIfNeeded(realm, lastChatEntry)
 }
 
 export function updateChatEntryMetadata(realm: Realm, recordId: string, metadata: Record<string, unknown>) {

--- a/src/hooks/agent/chat/subscribeToAgentChatEvents.ts
+++ b/src/hooks/agent/chat/subscribeToAgentChatEvents.ts
@@ -54,15 +54,9 @@ import {
   findAllByAssociatedRecordId,
   updateChatEntry,
 } from './services/ChatEntryService'
-import {
-  addUnread,
-  findChatThread,
-  findOrCreateChatThread,
-  updateThread,
-  updateThreadIfNeeded,
-} from './services/ChatThreadService'
+import { addUnread, findChatThread, findOrCreateChatThread, updateThread } from './services/ChatThreadService'
 
-import { ChatEntryType, ChatEntryRole, ChatEntryState, InvitationMetadata, ChatEntry } from '@2060/model'
+import { ChatEntryType, ChatEntryRole, ChatEntryState, InvitationMetadata } from '@2060/model'
 import { InvitationState } from '@2060/model/InvitationState'
 import { MobileAgent } from '@2060/services/agent'
 import {
@@ -214,13 +208,9 @@ export function subscribeToAgentChatEvents(
   // in a single write operation
   const messageReceiptsReceivedListener = async (data: MessageReceiptsReceivedEvent) => {
     const receipts = data.payload.receipts
-    let lastChatEntry: ChatEntry | undefined
-
     for (const receipt of receipts) {
-      const entry = addReceiptToRelatedEntries(realm, receipt)
-      if (entry && (!lastChatEntry || lastChatEntry?.createdAt < entry.createdAt)) lastChatEntry = entry
+      addReceiptToRelatedEntries(realm, receipt)
     }
-    if (lastChatEntry) updateThreadIfNeeded(realm, lastChatEntry)
   }
 
   const messageReactionsReceivedListener = async (data: MessageReactionsReceivedEvent) => {


### PR DESCRIPTION
call updateThreadIfNeeded in addReceiptToRelatedEntries due to it updates a chat entry receipt state. So, could be necessary update thread to see receipts updated in thread too