### PR TITLE
ci: migrate releases minio

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          sudo mv mc /usr/local/bin/
+          echo "$PWD" >> $GITHUB_PATH
           mc alias set myminio $MINIO_HOST $MINIO_USERNAME $MINIO_PASSWORD
           mc mb --ignore-existing myminio/repository/dev/hologram-app/$NEW_RELEASE_VERSION
           mc cp ./android/app/build/outputs/apk/dev/release/app-dev-release.apk myminio/repository/dev/hologram-app/$NEW_RELEASE_VERSION/app.apk
@@ -248,7 +248,7 @@ jobs:
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          sudo mv mc /usr/local/bin/
+          echo "$PWD" >> $GITHUB_PATH
           mc alias set myminio $MINIO_HOST $MINIO_USERNAME $MINIO_PASSWORD
 
       - name: Upload manifest.plist to MinIO

--- a/.github/workflows/staging-release.yml
+++ b/.github/workflows/staging-release.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          sudo mv mc /usr/local/bin/
+          echo "$PWD" >> $GITHUB_PATH
           mc alias set myminio $MINIO_HOST $MINIO_USERNAME $MINIO_PASSWORD
           mc mb --ignore-existing myminio/repository/staging/hologram-app/$NEW_RELEASE_VERSION
           mc cp ./android/app/build/outputs/apk/staging/release/app-staging-release.apk myminio/repository/staging/hologram-app/$NEW_RELEASE_VERSION/app.apk
@@ -249,7 +249,7 @@ jobs:
         run: |
           wget https://dl.min.io/client/mc/release/linux-amd64/mc
           chmod +x mc
-          sudo mv mc /usr/local/bin/
+          echo "$PWD" >> $GITHUB_PATH
           mc alias set myminio $MINIO_HOST $MINIO_USERNAME $MINIO_PASSWORD
 
       - name: Upload manifest.plist to MinIO


### PR DESCRIPTION
This PR updates our CI/CD pipeline to replace **Nexus** with **MinIO** as the artifact storage solution for release files (`.ipa`, `.apk`, and related manifests).

#### Changes

* Added MinIO client (`mc`) installation in CI workflows.
* Updated release jobs to upload artifacts to MinIO under:

* Uploads include:

  * `app.ipa` (iOS builds)
  * `app.apk` (Android builds)
  * `manifest.plist` and `install.html` (supporting files for iOS installation)

#### Access model

* Unlike Nexus, artifacts in MinIO do **not require a token** for download.
* Files in the `repository` bucket are publicly accessible via direct URLs for easier distribution.
**Note**: If required in the future, MinIO supports access control via **pre-signed URLs** (token-based downloads) or bucket policies, and we can switch to that model without changing the upload flow.