### PR TITLE
fix: avoid to call many times onBarcodeScanned

### DIFF
--- a/src/components/CodeScanner/CodeScanner.tsx
+++ b/src/components/CodeScanner/CodeScanner.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Dimensions, Platform, StyleSheet, View } from 'react-native'
 import {
@@ -29,25 +29,27 @@ interface Props {
 }
 
 const CodeScanner: React.FC<Props> = ({ isActive, onBarcodeScanned }) => {
+  const { t } = useTranslation()
+  const theme = useTheme()
+  const styles = getStyles(theme)
   const [cameraPermissionStatus, setCameraPermissionStatus] = useState<CameraPermissionStatus>()
+  const scannedCodes = useRef<string[]>([])
   const devices = useCameraDevices()
   const device = devices.find(dev => dev.position === 'back')
-  const theme = useTheme()
   const hasPermission = cameraPermissionStatus === 'granted'
-  const { t } = useTranslation()
-  const styles = getStyles(theme)
-  const [scannedCodes, setScannedCodes] = useState<string[]>([])
 
   useEffect(() => {
-    setScannedCodes([])
+    scannedCodes.current = []
   }, [isActive])
 
   const codeScanner = useCodeScanner({
     codeTypes: ['qr'],
     onCodeScanned: (codes: Code[]) => {
-      if (codes.length && codes[0].value && !scannedCodes.includes(codes[0].value)) {
-        setScannedCodes(prevScannedCodes => [...prevScannedCodes, codes[0].value ?? ''])
-        onBarcodeScanned(codes[0].value)
+      const scannedCode = codes[0].value
+      if (scannedCode) {
+        const hasNotBeenScanned = !scannedCodes.current.includes(scannedCode)
+        if (hasNotBeenScanned) onBarcodeScanned(scannedCode)
+        scannedCodes.current = [...scannedCodes.current, scannedCode]
       }
     },
   })

--- a/src/pages/Scan/Scan.tsx
+++ b/src/pages/Scan/Scan.tsx
@@ -43,11 +43,10 @@ const Scan = ({ navigation }: Props) => {
   const { isAppActive } = useAppState()
   const { agent } = useMobileAgent()
   const { t } = useTranslation()
-
-  const [isActive, setIsActive] = useState(false)
+  const [isActiveCamera, setIsActiveCamera] = useState(false)
 
   useEffect(() => {
-    setIsActive(isFocused && isAppActive)
+    setIsActiveCamera(isFocused && isAppActive)
   }, [isFocused, isAppActive])
 
   const behavior = Platform.OS === 'ios' ? 'padding' : 'height'
@@ -92,7 +91,7 @@ const Scan = ({ navigation }: Props) => {
   const processCode = async (codeUrl: string) => {
     if (!agent) throw new Error('Agent not defined')
     try {
-      setIsActive(false)
+      setIsActiveCamera(false)
       if (isOpenIdCredentialOffer(codeUrl)) {
         navigation.navigate('OpenIdCredentialOffer', { url: codeUrl })
       } else if (isOpenIdPresentationRequest(codeUrl)) {
@@ -114,7 +113,7 @@ const Scan = ({ navigation }: Props) => {
       }
       setScannedCode('')
     } catch (error) {
-      setIsActive(true)
+      setIsActiveCamera(true)
       toast({
         type: 'error',
         message: t('scan.errorProcessingCodeOrLink', { message: (error as Error).message }),
@@ -154,7 +153,7 @@ const Scan = ({ navigation }: Props) => {
           {t('scan.textDescriptionScanner')}
         </Text>
       </View>
-      <CodeScanner isActive={isActive} onBarcodeScanned={processCode} />
+      <CodeScanner isActive={isActiveCamera} onBarcodeScanned={processCode} />
     </View>
   )
 


### PR DESCRIPTION
Strange situation on iOS where a connection with gov-id-verifier service was being deleted it was due to same processed code was being processed by app so this generated several calls to processInvitation and for that reason it got errors. Now ensuring that this function is being called just one time this error is not thrown anymore and connection is not being deleted