### PR TITLE
fix: support webvh anoncreds

### DIFF
--- a/src/services/agent/MobileAgent.ts
+++ b/src/services/agent/MobileAgent.ts
@@ -39,7 +39,7 @@ import {
 import { OpenId4VcHolderModule } from '@credo-ts/openid4vc'
 import { PushNotificationsFcmModule } from '@credo-ts/push-notifications'
 import { QuestionAnswerModule } from '@credo-ts/question-answer'
-import { WebvhDidResolver } from '@credo-ts/webvh'
+import { WebVhAnonCredsRegistry, WebvhDidResolver } from '@credo-ts/webvh'
 import { anoncreds } from '@hyperledger/anoncreds-react-native'
 import { ariesAskar } from '@hyperledger/aries-askar-react-native'
 import { DidWebAnonCredsRegistry } from 'credo-ts-didweb-anoncreds'
@@ -61,6 +61,7 @@ export const getMobileAgentModules = (config: {
         new DidWebAnonCredsRegistry({
           cacheOptions: { allowCaching: true, cacheDurationInSeconds: SECONDS_PER_DAY },
         }),
+        new WebVhAnonCredsRegistry(),
         new IndyVdrProxyAnonCredsRegistry({
           proxyBaseUrl,
           headers: getAppCheckHeaders,


### PR DESCRIPTION
Supporting did:webvh AnonCreds objects now that VS Agent is going to support issuance and verification using this DID method.

This can be tested now with latest Chatbot demo (deployed in dev environment).