### PR TITLE
fix: print data error message as comes from origin to avoid lost output

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ import { name as appName } from './app.json'
 import AppHeadless from './src/AppHeadless'
 import { backgroundPushNotificationHandler } from './src/services/backgroundPushNotificationHandler'
 
+const formatter = (_, msg) => {
+  const now = new Date()
+  return `${now.toISOString()} ${msg}`
+}
+
 const TEN_MB = 1024 * 1024 * 10
 import { LOGS_DIRECTORY, log, logError } from '@2060/utils/log'
 // Register handler for FCM notifications when app is in quit state
@@ -18,6 +23,7 @@ FileLogger.configure({
   logsDirectory: LOGS_DIRECTORY,
   logPrefix: 'hologram',
   maximumFileSize: TEN_MB,
+  formatter,
 })
   .then(() => log('react-native-file-logger setup!'))
   .catch(error => logError(`An error has occurred configuring react-native-file-logger: ${error}`))

--- a/src/services/HologramCustomLoggers.ts
+++ b/src/services/HologramCustomLoggers.ts
@@ -44,17 +44,17 @@ export class HologramCustomLogger implements Logger {
   }
   warn(message: string, data?: Record<string, unknown>) {
     if (LogLevel.warn >= this.logLevel) {
-      console.warn(`WARN: ${message}`, data ? JSON.stringify(data, null, '\t') : '')
+      console.warn(`WARN: ${message}`, data)
     }
   }
   error(message: string, data?: Record<string, unknown>) {
     if (LogLevel.error >= this.logLevel) {
-      console.error(`ERROR: ${message}`, data ? JSON.stringify(data, null, '\t') : '')
+      console.error(`ERROR: ${message}`, data)
     }
   }
   fatal(message: string, data?: Record<string, unknown>) {
     if (LogLevel.fatal >= this.logLevel) {
-      console.error(`FATAL: ${message}`, data ? JSON.stringify(data, null, '\t') : '')
+      console.error(`FATAL: ${message}`, data)
     }
   }
 }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -6,15 +6,15 @@ import { toast } from './toast'
 export const LOGS_DIRECTORY = `${DocumentDirectoryPath}/hologramLogs`
 export function log(message: string, ...optionalParams: unknown[]) {
   if (__DEV__) {
-    console.log(message, ...optionalParams)
+    console.log(`APP_DEBUG: ${message}`, ...optionalParams)
   }
 }
 
 export function logError(message: string, ...optionalParams: unknown[]) {
-  console.error(message, ...optionalParams)
+  console.error(`APP_ERROR: ${message}`, ...optionalParams)
 }
 
 export function logWarn(message: string, displayToast = false) {
   if (displayToast) toast({ message, type: 'warning' })
-  console.warn(message)
+  console.warn(`APP_WARN: ${message}`)
 }


### PR DESCRIPTION
due to complexity of error messages in some cases error output was error:{} which did not represent real error output from credo. With this adjustment credo error displays as has to