### PR TITLE
fix: generate new invitation if current one is not found

### DIFF
--- a/src/pages/Developer/Developer.tsx
+++ b/src/pages/Developer/Developer.tsx
@@ -23,6 +23,7 @@ import { useTheme } from '@2060/hooks/providers/ThemeProvider'
 import { AgentActionQueueSingleton } from '@2060/services/AgentActionQueueSingleton'
 import AgentSingleton from '@2060/services/AgentSingleton'
 import { deleteAllKeys } from '@2060/services/keys'
+import { removeStorageData, USER_INVITATION_OUT_OF_BAND_RECORD_ID } from '@2060/services/localStorage'
 import { deleteDir, walletDirectoryPath } from '@2060/utils/RNFS'
 import {
   allDevEnvs,
@@ -129,6 +130,7 @@ const Developer = ({ navigation }: Props) => {
       await agent.modules.askar.deleteStore()
       await deleteDir(walletDirectoryPath)
       await deleteAllKeys()
+      await removeStorageData(USER_INVITATION_OUT_OF_BAND_RECORD_ID)
       closeRealm()
       AgentSingleton.instance.setAppIsSubscribedChatToEvents(false)
       AgentSingleton.instance.setIsAppSubscribedToConnectionEvents(false)

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -22,6 +22,7 @@ import { useTheme } from '@2060/hooks/providers/ThemeProvider'
 import { AgentActionQueueSingleton } from '@2060/services/AgentActionQueueSingleton'
 import { AgentSingleton } from '@2060/services/AgentSingleton'
 import { deleteAllKeys } from '@2060/services/keys'
+import { removeStorageData, USER_INVITATION_OUT_OF_BAND_RECORD_ID } from '@2060/services/localStorage'
 import { logError, dataUrl } from '@2060/utils'
 import { deleteDir, walletDirectoryPath } from '@2060/utils/RNFS'
 import { toast } from '@2060/utils/toast'
@@ -86,6 +87,7 @@ const Settings = ({ navigation }: Props) => {
       await agent.modules.askar.deleteStore()
       await deleteDir(walletDirectoryPath)
       await deleteAllKeys()
+      await removeStorageData(USER_INVITATION_OUT_OF_BAND_RECORD_ID)
       closeRealm()
       AgentSingleton.instance.setAppIsSubscribedChatToEvents(false)
       AgentSingleton.instance.setIsAppSubscribedToConnectionEvents(false)

--- a/src/pages/UserInvitation/withUserInvitation.tsx
+++ b/src/pages/UserInvitation/withUserInvitation.tsx
@@ -37,9 +37,10 @@ const withUserInvitation = (UserInvitationComponent: ElementType<UserInvitationP
     const getCurrentInvitation = async () => {
       if (!agent) return
       try {
-        const persistedOutOfBandRecordId = (await getStorageData(
-          USER_INVITATION_OUT_OF_BAND_RECORD_ID,
-        )) as string
+        const persistedOutOfBandRecordId = (await getStorageData(USER_INVITATION_OUT_OF_BAND_RECORD_ID)) as
+          | string
+          | null
+        if (!persistedOutOfBandRecordId) return
 
         currentInvitationOutOfBandRecordId.current = persistedOutOfBandRecordId
         const { outOfBandInvitation } = await getOutOfBandRecordById(agent, persistedOutOfBandRecordId)

--- a/src/services/localStorage/index.ts
+++ b/src/services/localStorage/index.ts
@@ -43,7 +43,7 @@ export const SCREEN_LOCK_ENABLED_PERSIST_KEY = 'screenLockEnabled'
 // This storage key saves the id of the OutOfBandRecord when user creates his invitation to share it
 export const USER_INVITATION_OUT_OF_BAND_RECORD_ID = 'userInvitationOutOfBandRecordId'
 
-export const setStorageData = async (key: string, value: unknown) => {
+export async function setStorageData(key: string, value: unknown) {
   try {
     const jsonValue = JSON.stringify(value)
     await AsyncStorage.setItem(key, jsonValue)
@@ -53,12 +53,21 @@ export const setStorageData = async (key: string, value: unknown) => {
   }
 }
 
-export const getStorageData = async (key: string): Promise<unknown | null | undefined> => {
+export async function getStorageData(key: string): Promise<unknown | null | undefined> {
   try {
     const value = await AsyncStorage.getItem(key)
     if (value) return JSON.parse(value)
     return null
   } catch (error) {
     return null
+  }
+}
+
+export async function removeStorageData(key: string): Promise<boolean> {
+  try {
+    await AsyncStorage.removeItem(key)
+    return true
+  } catch (error) {
+    return false
   }
 }


### PR DESCRIPTION
This happened to me because I deleted the wallet and USER_INVITATION_OUT_OF_BAND_RECORD_ID was not cleared. This is one of the reasons why I don't like to have app data split in different databases. Anyway, this fix handles this and any other reason why the current invitation code is invalid, and simply generates a new one, showing a warning of this unexpected situation.