### PR TITLE
fix: if user accepts a credential offer coming from chat screen just go back to chat screen

### DIFF
--- a/src/components/Navigation/NavigationProps.ts
+++ b/src/components/Navigation/NavigationProps.ts
@@ -28,7 +28,7 @@ export type NavigationStackParams = {
   PersonalChatStack: undefined
   OpenIdCredentialOffer: { url: string }
   OpenIdPresentationRequest: { url: string }
-  DidcommCredentialOffer: { credentialRecordId: string; did: string }
+  DidcommCredentialOffer: { credentialRecordId: string; did?: string }
   DidcommPresentationRequest: { did: string; proofRecordId: string }
   ConnectionInvitation: { outOfBandRecord: DidCommOutOfBandRecord; existingConnectionId?: string }
   ConnectionDetails: { connectionId: string }

--- a/src/pages/CredentialOffer/DidcommCredentialOffer.tsx
+++ b/src/pages/CredentialOffer/DidcommCredentialOffer.tsx
@@ -37,9 +37,9 @@ const DidcommCredentialOffer: React.FC<Props> = ({ route, navigation }) => {
     }
   }
 
-  const goToChatScreen = async () => {
+  const goToChatScreen = async (invitationDid: string) => {
     if (!agent) return
-    const connections = await agent.didcomm.connections.findByInvitationDid(did)
+    const connections = await agent.didcomm.connections.findByInvitationDid(invitationDid)
     if (connections.length) {
       const [connection] = connections
       const chatThreadId = findOrCreateThread({ connection }).id
@@ -59,7 +59,7 @@ const DidcommCredentialOffer: React.FC<Props> = ({ route, navigation }) => {
       type: AgentActionType.AcceptCredentialOffer,
       parameters,
     })
-    goToChatScreen()
+    did ? goToChatScreen(did) : navigation.goBack()
   }
 
   const refuse = () => {
@@ -69,7 +69,7 @@ const DidcommCredentialOffer: React.FC<Props> = ({ route, navigation }) => {
       type: AgentActionType.DeclineCredentialOffer,
       parameters,
     })
-    goToChatScreen()
+    did ? goToChatScreen(did) : navigation.goBack()
   }
 
   if (!credentialDetails) return null


### PR DESCRIPTION
This PR is to solve an injected bug implemented in https://github.com/2060-io/hologram-app/pull/401 due to when user accepts a credential offer and comes from chat does not have and invitationDid and just need to go back to chat when accepts or reject a credential offer