### PR TITLE
fix: sign-up error in release mode

### DIFF
--- a/src/hooks/providers/PushNotificationsProvider.tsx
+++ b/src/hooks/providers/PushNotificationsProvider.tsx
@@ -54,7 +54,7 @@ export const PushNotificationsProvider: React.FC<React.PropsWithChildren<Props>>
       })
     })
     return () => unsubscribe()
-  }, [agent, addAgentActionToQueue])
+  }, [agent?.isInitialized, isSignedUp])
 
   useEffect(() => {
     const verifyPushNotificationTokenIsRegistered = async () => {


### PR DESCRIPTION
Using wallet file existence to determine if wallet can be opened due to some issues found when running the app in dev mode. I think it was because of some concurrency, so this fix can be seen as a workaround until we do some adjustements in the way the agent/wallet lifecycle is managed.