### PR TITLE
fix: update chatEntry state to Submitted when send a message in a retry agent action

### DIFF
--- a/src/services/AgentActionQueueSingleton.ts
+++ b/src/services/AgentActionQueueSingleton.ts
@@ -20,6 +20,8 @@ import {
   RetryAgentAction,
 } from '@src/hooks/agent/actions/AgentAction'
 import { AgentActionExecuter } from '@src/hooks/agent/actions/AgentActionExecuter'
+import { updateChatEntry } from '@src/hooks/agent/chat/services'
+import { ChatEntry, ChatEntryState } from '@src/model'
 import { log, logError } from '@src/utils'
 
 class ActionExecutionError extends Error {
@@ -131,6 +133,14 @@ export class AgentActionQueueSingleton {
                 connectionRecord,
               }),
             )
+            const associatedChatEntryId = payload.outboundMessageContextData.associatedChatEntryId
+            const chatEntry = associatedChatEntryId
+              ? realm.objectForPrimaryKey(ChatEntry, associatedChatEntryId)
+              : undefined
+            // Message is submitted: update the associated chat entry to the corresponding state
+            if (chatEntry && chatEntry.state === ChatEntryState.Created) {
+              updateChatEntry(realm, { recordId: chatEntry.id, state: ChatEntryState.Submitted })
+            }
           } catch (error) {
             logError(`error trying resending message: ${error}`)
             throw new ActionExecutionError('Execution error', payload.outboundMessageContextData)


### PR DESCRIPTION
currently when app retries to send a message and send it is not updating related chat entry message to submitted (single ack check) giving impression that message was not re-sent when really it was done