### PR TITLE
fix: verre VC signature validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@sharcoux/slider": "8.0.6",
     "@simform_solutions/react-native-audio-waveform": "2.1.6",
     "isomorphic-webcrypto": "npm:@sphereon/isomorphic-webcrypto@2.5.0-rn-crypto.2",
-    "@verana-labs/verre": "^0.2.0",
+    "@verana-labs/verre": "^0.2.1",
     "axios": "^0.25.0",
     "credo-ts-didweb-anoncreds": "^0.0.2-alpha.4",
     "credo-ts-indy-vdr-proxy-client": "^0.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,10 +5539,10 @@
     "@urql/core" "^5.1.1"
     wonka "^6.3.2"
 
-"@verana-labs/verre@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@verana-labs/verre/-/verre-0.2.0.tgz#a5f9f64f1cfac3cce387e0fdd31d9d26d7af1427"
-  integrity sha512-3xufr+ct//Yo0Q6BYdbYRf08HXGSVqPceyebDJZKxCDahGktydAHmmo3hX4G+DSXoXXAmlXVIAQmValXa1tuqw==
+"@verana-labs/verre@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@verana-labs/verre/-/verre-0.2.1.tgz#bef7ac979c28b63f530aad439389c998f208ea10"
+  integrity sha512-Ib4KtpFUGczHp8q8pvW4hbioC3Rh7KtBrB+hJH786QDrmhVFgW8NxE8xzkdIR+I1YbHgPlXYoalACPR5FUk5Gg==
   dependencies:
     "@digitalcredentials/jsonld" "^9.0.0"
     "@noble/curves" "^2.0.1"


### PR DESCRIPTION
Quick fix from verre to properly validate the signature of all credentials belonging to a presentation during verifiable trust resolution.