### PR TITLE
fix: SVG support for avatars and credentail attributes

### DIFF
--- a/src/components/CredentialAttribute/CredentialAttribute.tsx
+++ b/src/components/CredentialAttribute/CredentialAttribute.tsx
@@ -1,7 +1,6 @@
 import { Skeleton } from 'moti/skeleton'
 import React from 'react'
 import { View, TouchableOpacity, StyleProp, ImageStyle, ViewStyle } from 'react-native'
-import EIdReader from 'react-native-eid-reader'
 
 import getStyles from './styles'
 
@@ -16,15 +15,10 @@ type ImageSectionProps = {
   imageStyle: StyleProp<ImageStyle>
 }
 
-const isJpeg2000DataUrl = (uri: string) =>
-  uri.includes('data:image/jp2') || uri.includes('data:image/jpeg2000')
-
 const ImageAttribute = ({ image, onPressDetailImage, imageStyle }: ImageSectionProps) => {
-  const imageUri = isJpeg2000DataUrl(image) ? EIdReader.imageDataUrlToJpegDataUrl(image) : image
-
-  return imageUri ? (
-    <TouchableOpacity onPress={() => onPressDetailImage?.(imageUri)}>
-      <UniversalImage style={imageStyle} resizeMode="contain" source={{ uri: imageUri }} />
+  return image ? (
+    <TouchableOpacity onPress={() => onPressDetailImage?.(image)}>
+      <UniversalImage style={imageStyle} resizeMode="contain" source={{ uri: image }} />
     </TouchableOpacity>
   ) : null
 }

--- a/src/components/CredentialAttribute/CredentialAttribute.tsx
+++ b/src/components/CredentialAttribute/CredentialAttribute.tsx
@@ -1,11 +1,11 @@
 import { Skeleton } from 'moti/skeleton'
 import React from 'react'
-import { View, Image, TouchableOpacity, StyleProp, ImageStyle, ViewStyle } from 'react-native'
+import { View, TouchableOpacity, StyleProp, ImageStyle, ViewStyle } from 'react-native'
 import EIdReader from 'react-native-eid-reader'
 
 import getStyles from './styles'
 
-import { Text } from '@src/components/common'
+import { Text, UniversalImage } from '@src/components/common'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import { sanitizeString } from '@src/services/agent/display'
 import { CredentialAttributeRow } from '@src/services/agent/formatCredentialSubject'
@@ -16,12 +16,15 @@ type ImageSectionProps = {
   imageStyle: StyleProp<ImageStyle>
 }
 
-const ImageAttribute = ({ image, onPressDetailImage, imageStyle }: ImageSectionProps) => {
-  const jpegImage = EIdReader.imageDataUrlToJpegDataUrl(image)
+const isJpeg2000DataUrl = (uri: string) =>
+  uri.includes('data:image/jp2') || uri.includes('data:image/jpeg2000')
 
-  return jpegImage ? (
-    <TouchableOpacity onPress={() => onPressDetailImage?.(jpegImage)}>
-      <Image style={imageStyle} resizeMode="contain" source={{ uri: jpegImage }} />
+const ImageAttribute = ({ image, onPressDetailImage, imageStyle }: ImageSectionProps) => {
+  const imageUri = isJpeg2000DataUrl(image) ? EIdReader.imageDataUrlToJpegDataUrl(image) : image
+
+  return imageUri ? (
+    <TouchableOpacity onPress={() => onPressDetailImage?.(imageUri)}>
+      <UniversalImage style={imageStyle} resizeMode="contain" source={{ uri: imageUri }} />
     </TouchableOpacity>
   ) : null
 }

--- a/src/components/common/Avatar/Avatar.tsx
+++ b/src/components/common/Avatar/Avatar.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Image, TouchableOpacity, View } from 'react-native'
-import { SvgUri } from 'react-native-svg'
+import { TouchableOpacity, View } from 'react-native'
 
 import SmartImage from './SmartImage'
 import getStyles from './styles'
@@ -14,10 +13,6 @@ const getNameInitials = (fullName: string) => {
   const firstName = nameParts[0]?.[0] || ''
   const lastName = nameParts[1]?.[0] || ''
   return (firstName + lastName).toUpperCase()
-}
-
-const isHttpUrl = (uri: string) => {
-  return uri.startsWith('https://') || uri.startsWith('http://')
 }
 
 const isUri = (value: string) => /\w+:(\/?\/?)[^\s]+/.test(value)
@@ -64,15 +59,7 @@ const Avatar: React.FC<Props> = ({
       disabled={!onImagePressed}
       onPress={() => onImagePressed?.(imageUri.current ?? '')}
     >
-      {uri?.endsWith('.svg') || uri?.includes('data:image/svg+xml') ? (
-        <SvgUri
-          uri={uri}
-          style={styles.avatar}
-          width={styles.avatar.width}
-          height={styles.avatar.height}
-          onError={() => setIsValidImageUrl(false)}
-        />
-      ) : uri && isHttpUrl(uri) ? (
+      {uri && (
         <SmartImage
           uri={uri}
           setIsValidImageUrl={setIsValidImageUrl}
@@ -80,8 +67,6 @@ const Avatar: React.FC<Props> = ({
           style={styles.avatar}
           enableImageRefresh={enableImageRefresh}
         />
-      ) : (
-        <Image source={{ uri }} style={styles.avatar} onError={() => setIsValidImageUrl(false)} />
       )}
     </TouchableOpacity>
   )

--- a/src/components/common/Avatar/SmartImage/SmartImage.tsx
+++ b/src/components/common/Avatar/SmartImage/SmartImage.tsx
@@ -1,21 +1,51 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ImageStyle, Image, StyleProp } from 'react-native'
 
 import { useImage } from './useImage'
 
+import UniversalImage, { isSvgUri } from '@src/components/common/UniversalImage'
+
+const isHttpUrl = (uri: string) => uri.startsWith('https://') || uri.startsWith('http://')
+
 type Props = {
   uri: string
-  setIsValidImageUrl: (isValid: boolean) => void
-  onImageContent: (imageContent: string) => void
+  setIsValidImageUrl?: (isValid: boolean) => void
+  onImageContent?: (imageContent: string) => void
   style?: StyleProp<ImageStyle>
-  enableImageRefresh: boolean
+  enableImageRefresh?: boolean
 }
 
-const SmartImage = ({ uri, setIsValidImageUrl, onImageContent, style, enableImageRefresh }: Props) => {
-  const onError = () => setIsValidImageUrl(false)
-  const { imageContent } = useImage({ uri, onError, onImageContent, enableImageRefresh })
+const CachedImage = ({
+  uri,
+  setIsValidImageUrl,
+  onImageContent,
+  style,
+  enableImageRefresh = true,
+}: Props) => {
+  const onError = () => setIsValidImageUrl?.(false)
+  const handleImageContent = onImageContent ?? (() => {})
+  const { imageContent } = useImage({ uri, onError, onImageContent: handleImageContent, enableImageRefresh })
 
   return imageContent ? <Image source={{ uri: imageContent }} style={style} /> : null
+}
+
+const DirectImage = ({ uri, setIsValidImageUrl, onImageContent, style }: Props) => {
+  useEffect(() => {
+    onImageContent?.(uri)
+  }, [uri])
+
+  const handleError = () => setIsValidImageUrl?.(false)
+  return <UniversalImage source={{ uri }} style={style} onError={handleError} onImageError={handleError} />
+}
+
+const SmartImage = (props: Props) => {
+  const { uri } = props
+
+  if (isHttpUrl(uri) && !isSvgUri(uri)) {
+    return <CachedImage {...props} />
+  }
+
+  return <DirectImage {...props} />
 }
 
 export default SmartImage

--- a/src/components/common/CredentialMainInformation/DumbCredentialMainInformation.tsx
+++ b/src/components/common/CredentialMainInformation/DumbCredentialMainInformation.tsx
@@ -1,12 +1,12 @@
 import { Skeleton } from 'moti/skeleton'
 import React, { memo, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Image, TouchableOpacity, ActivityIndicator } from 'react-native'
+import { View, TouchableOpacity, ActivityIndicator } from 'react-native'
 import { uses24HourClock } from 'react-native-localize'
-import { SvgUri } from 'react-native-svg'
 
 import SvgIcon from '../SvgIcon'
 import Text from '../Text'
+import UniversalImage from '../UniversalImage'
 import VerifiedIcon from '../VerifiedIcon'
 
 import { DumbCredentialMainInformationProps } from './Pros'
@@ -49,17 +49,11 @@ const DumbCredentialMainInformation = ({
       )
     }
     return (
-      <>
-        {uri?.endsWith('.svg') ? (
-          <SvgUri uri={uri} width={styles.image.width} height={styles.image.height} />
-        ) : (
-          <Image
-            style={styles.image}
-            resizeMode="contain"
-            source={uri?.length ? { uri } : imagePlaceholder}
-          />
-        )}
-      </>
+      <UniversalImage
+        style={styles.image}
+        resizeMode="contain"
+        source={uri?.length ? { uri } : imagePlaceholder}
+      />
     )
   }, [isFetchingInfo, failedFetchInfo, uri])
 

--- a/src/components/common/FullScreenImage/FullScreenImage.tsx
+++ b/src/components/common/FullScreenImage/FullScreenImage.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
-import { Image, View, TouchableWithoutFeedback } from 'react-native'
+import { View, TouchableWithoutFeedback } from 'react-native'
 
 import Modal from '../Modal'
 import SvgIcon from '../SvgIcon'
+import UniversalImage from '../UniversalImage'
 
 import styles from './styles'
 
@@ -18,7 +19,7 @@ const FullScreenImage = ({ showFullScreenImage, closeFullScreenImage, imageUri }
       <TouchableWithoutFeedback onPress={closeFullScreenImage}>
         <View style={styles.container}>
           <SvgIcon name="close" width={30} height={30} fill="white" style={styles.closeIcon} />
-          <Image style={styles.image} resizeMode="contain" source={{ uri: imageUri }} />
+          <UniversalImage style={styles.image} resizeMode="contain" source={{ uri: imageUri }} />
         </View>
       </TouchableWithoutFeedback>
     </Modal>

--- a/src/components/common/UniversalImage/UniversalImage.tsx
+++ b/src/components/common/UniversalImage/UniversalImage.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { Image, ImageProps, ImageStyle, StyleProp } from 'react-native'
+import { NumberProp, SvgUri } from 'react-native-svg'
+
+const isSvgUri = (uri?: string) => uri?.endsWith('.svg') || uri?.includes('data:image/svg+xml')
+
+type Props = ImageProps & {
+  svgWidth?: NumberProp
+  svgHeight?: NumberProp
+  onImageError?: () => void
+}
+
+const UniversalImage = ({ svgWidth, svgHeight, onImageError, ...imageProps }: Props) => {
+  const source = imageProps.source
+  const uri = source && typeof source === 'object' && 'uri' in source ? source.uri : undefined
+
+  if (uri && isSvgUri(uri)) {
+    const flatStyle = (
+      imageProps.style
+        ? Object.assign({}, ...(Array.isArray(imageProps.style) ? imageProps.style : [imageProps.style]))
+        : {}
+    ) as ImageStyle
+
+    const width = svgWidth ?? (flatStyle.width as NumberProp) ?? '100%'
+    const height = svgHeight ?? (flatStyle.height as NumberProp) ?? '100%'
+
+    return (
+      <SvgUri
+        uri={uri}
+        style={imageProps.style as StyleProp<ImageStyle>}
+        width={width}
+        height={height}
+        onError={onImageError}
+      />
+    )
+  }
+
+  return <Image {...imageProps} />
+}
+
+export { isSvgUri }
+export default UniversalImage

--- a/src/components/common/UniversalImage/UniversalImage.tsx
+++ b/src/components/common/UniversalImage/UniversalImage.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
 import { Image, ImageProps, ImageStyle, StyleProp } from 'react-native'
+import EIdReader from 'react-native-eid-reader'
 import { NumberProp, SvgUri } from 'react-native-svg'
 
 const isSvgUri = (uri?: string) => uri?.endsWith('.svg') || uri?.includes('data:image/svg+xml')
+
+const isJpeg2000DataUrl = (uri?: string) =>
+  uri?.includes('data:image/jp2') || uri?.includes('data:image/jpeg2000')
 
 type Props = ImageProps & {
   svgWidth?: NumberProp
@@ -35,7 +39,10 @@ const UniversalImage = ({ svgWidth, svgHeight, onImageError, ...imageProps }: Pr
     )
   }
 
-  return <Image {...imageProps} />
+  const resolvedSource =
+    uri && isJpeg2000DataUrl(uri) ? { uri: EIdReader.imageDataUrlToJpegDataUrl(uri) } : imageProps.source
+
+  return <Image {...imageProps} source={resolvedSource} />
 }
 
 export { isSvgUri }

--- a/src/components/common/UniversalImage/index.ts
+++ b/src/components/common/UniversalImage/index.ts
@@ -1,0 +1,4 @@
+import UniversalImage, { isSvgUri } from './UniversalImage'
+
+export { isSvgUri }
+export default UniversalImage

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -18,6 +18,7 @@ import Switch from './Switch'
 import Text from './Text'
 import TextInput from './TextInput'
 import TextInputPassword from './TextInputPassword'
+import UniversalImage from './UniversalImage'
 import VerifiedIcon from './VerifiedIcon'
 
 export * from './ServiceInformation'
@@ -45,4 +46,5 @@ export {
   RadioButton,
   FullScreenImage,
   ConnectionRefusedByAge,
+  UniversalImage,
 }

--- a/src/pages/Chat/ContextualMenu/ContextualMenu.tsx
+++ b/src/pages/Chat/ContextualMenu/ContextualMenu.tsx
@@ -1,10 +1,10 @@
 import React, { memo } from 'react'
-import { TouchableOpacity, View, Image } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 
 import { ContextualMenuProps } from './ContextualMenuProps'
 import getStyles from './styles'
 
-import { Text } from '@src/components/common'
+import { Text, UniversalImage } from '@src/components/common'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 
 const ContextualMenu = ({ onSelectOption, connectionIconUrl, menu }: ContextualMenuProps) => {
@@ -15,7 +15,7 @@ const ContextualMenu = ({ onSelectOption, connectionIconUrl, menu }: ContextualM
     <View style={styles.containerActionsMenu}>
       <View style={styles.containerMenuHeader}>
         {connectionIconUrl && (
-          <Image source={{ uri: connectionIconUrl }} resizeMethod="resize" style={styles.image} />
+          <UniversalImage source={{ uri: connectionIconUrl }} resizeMethod="resize" style={styles.image} />
         )}
         <View style={styles.containerActionHeader}>
           {menu.title && (

--- a/src/pages/Chat/HtmlChatView/HtmlChatView.tsx
+++ b/src/pages/Chat/HtmlChatView/HtmlChatView.tsx
@@ -1,7 +1,7 @@
 import { OrientationLock, lockAsync, unlockAsync } from 'expo-screen-orientation'
 import React, { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Image, TouchableOpacity, View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context'
 import { SvgUri } from 'react-native-svg'
 import WebView from 'react-native-webview'
@@ -11,7 +11,7 @@ import { Header, BlueButton } from '../components'
 import { HtmlChatViewProps } from './HtmlChatViewProps'
 import getStyles from './styles'
 
-import { Modal, SvgIcon, Text } from '@src/components/common'
+import { Modal, SvgIcon, Text, UniversalImage } from '@src/components/common'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import { log, logError } from '@src/utils'
 
@@ -70,7 +70,7 @@ const HtmlChatView = (props: HtmlChatViewProps) => {
               onError={handleImageError}
             />
           ) : (
-            <Image style={styles.image} source={{ uri: metadata.icon }} onError={handleImageError} />
+            <UniversalImage style={styles.image} source={{ uri: metadata.icon }} onError={handleImageError} />
           ))}
         <View style={styles.detailsContainer}>
           <Text style={styles.title}>{metadata.title}</Text>

--- a/src/pages/Chat/ImageChatView/ImageChatView.tsx
+++ b/src/pages/Chat/ImageChatView/ImageChatView.tsx
@@ -10,7 +10,7 @@ import ImageView from './ImageView'
 import getStyles from './styles'
 
 import imagePlaceholder from '@src/assets/images/placeholderImg.png'
-import { Icon, Text, Progress } from '@src/components/common'
+import { Icon, Text, Progress, UniversalImage } from '@src/components/common'
 import { useMedia } from '@src/hooks'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import { ImageMetadata, MediaDownloadState, MediaUploadState } from '@src/model'
@@ -113,7 +113,7 @@ const ImageChatView = (props: ImageProps) => {
         </>
       ) : (
         <>
-          <Image source={imagePreview} style={imageStyle} />
+          <UniversalImage source={imagePreview} style={imageStyle} />
           <View style={styles.containerSpinner}>
             {isDownloading ? (
               <React.Fragment>

--- a/src/pages/Chat/ImageChatView/ImageView.tsx
+++ b/src/pages/Chat/ImageChatView/ImageView.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useState } from 'react'
-import { Image, StyleProp, ImageStyle, TouchableOpacity } from 'react-native'
+import { StyleProp, ImageStyle, TouchableOpacity } from 'react-native'
 
 import { MediaInfo } from '../ChatProps'
 
@@ -7,6 +7,7 @@ import LightboxHeader from './LightboxHeader'
 import getStyles from './styles'
 
 import { LightboxModal } from '@src/components'
+import { UniversalImage } from '@src/components/common'
 import { useChat } from '@src/hooks/agent'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import { ChatEntryMessage } from '@src/pages/Chat/ChatMessage/Props'
@@ -51,11 +52,11 @@ const ImageView = memo((props: ImageView) => {
         }
       >
         <TouchableOpacity onPress={handleControls} activeOpacity={1}>
-          <Image source={{ uri: imageUri }} style={styles.imageLightbox} />
+          <UniversalImage source={{ uri: imageUri }} style={styles.imageLightbox} />
         </TouchableOpacity>
       </LightboxModal>
       <TouchableOpacity onPress={onToggleModalLightbox} onLongPress={onLongPress}>
-        <Image style={props.style} source={{ uri: imagePreviewUri }} />
+        <UniversalImage style={props.style} source={{ uri: imagePreviewUri }} />
       </TouchableOpacity>
     </>
   )

--- a/src/pages/ConnectionDetails/ConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails/ConnectionDetails.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Image } from 'react-native'
+import { View } from 'react-native'
 import { uses24HourClock } from 'react-native-localize'
 
 import BaseConnectionDetails, { ConnectionDetailsProps, WrapperProps } from './BaseConnectionDetails'
@@ -8,6 +8,7 @@ import ConnectionDetailsForService from './ConnectionDetailsForService'
 import getStyles from './styles'
 
 import { Avatar, FullScreenImage, Text } from '@src/components/common'
+import UniversalImage from '@src/components/common/UniversalImage'
 import { useConnectionById } from '@src/hooks/agent'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import {
@@ -81,7 +82,10 @@ const ConnectionDetails = (props: ConnectionDetailsProps) => {
                 <View style={styles.relatedConnectionContainer}>
                   <Text style={styles.connectionRelatedToText}>{t('connection.connectionManagedBy')}</Text>
                   {parentConnectionPicture.length > 0 && (
-                    <Image source={{ uri: parentConnectionPicture }} style={styles.connectionRelatedToImg} />
+                    <UniversalImage
+                      source={{ uri: parentConnectionPicture }}
+                      style={styles.connectionRelatedToImg}
+                    />
                   )}
                   <Text style={styles.connectionRelatedToText}>{parentConnectionName}</Text>
                 </View>

--- a/src/pages/RelatedConnections/RelatedConnections.tsx
+++ b/src/pages/RelatedConnections/RelatedConnections.tsx
@@ -2,7 +2,7 @@ import { DidCommConnectionRecord } from '@credo-ts/didcomm'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Image, TouchableOpacity } from 'react-native'
+import { View, TouchableOpacity } from 'react-native'
 import { AlphabetList, IData } from 'react-native-section-alphabet-list'
 
 import getStyles from './styles'
@@ -10,6 +10,7 @@ import getStyles from './styles'
 import { SearchInput } from '@src/components'
 import { NavigationStackParams } from '@src/components/Navigation/NavigationProps'
 import { Avatar, SvgIcon, Text } from '@src/components/common'
+import UniversalImage from '@src/components/common/UniversalImage'
 import { useConnectionById, useConnectionByParentConnectionId } from '@src/hooks/agent'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
 import { getConnectionDisplayName, getConnectionDisplayPicture } from '@src/utils/connectionUtils'
@@ -57,7 +58,7 @@ const RelatedConnections: React.FC<Props> = ({ navigation, route }) => {
     <View style={styles.containerHeaderTitle}>
       {haveParentDisplayImage && (
         <View style={styles.containerImage}>
-          <Image source={{ uri: haveParentDisplayImage }} style={styles.avatarHeader} />
+          <UniversalImage source={{ uri: haveParentDisplayImage }} style={styles.avatarHeader} />
         </View>
       )}
       <Text style={styles.titleHeader} fontFamily="EuclidCircularA-Medium" numberOfLines={1}>

--- a/src/pages/SubChats/SubChats.tsx
+++ b/src/pages/SubChats/SubChats.tsx
@@ -2,7 +2,7 @@ import { StackActions } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack'
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { View, Image, TouchableOpacity, FlatList } from 'react-native'
+import { View, TouchableOpacity, FlatList } from 'react-native'
 import { uses24HourClock } from 'react-native-localize'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { SwipeRow } from 'react-native-swipe-list-view'
@@ -18,6 +18,7 @@ import {
   ChatFilterOptions,
 } from '@src/components'
 import { Text, SvgIcon, HeaderTitle } from '@src/components/common'
+import UniversalImage from '@src/components/common/UniversalImage'
 import { useChatThreadById, useChatThreadsbyParentId, useChats, useMobileAgent } from '@src/hooks/agent'
 import { deleteConnection } from '@src/hooks/agent/connections'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
@@ -110,7 +111,7 @@ const SubChats: React.FC<Props> = ({ route, navigation }) => {
       <View style={styles.containerHeaderTitle}>
         {parentChatThread?.picture && (
           <View style={styles.containerImage}>
-            <Image source={{ uri: parentChatThread.picture }} style={styles.avatarHeader} />
+            <UniversalImage source={{ uri: parentChatThread.picture }} style={styles.avatarHeader} />
           </View>
         )}
         <HeaderTitle title={parentChatThread?.topic ?? ''} theme={theme} />


### PR DESCRIPTION
Add support to SVG images in credential attributes, and centralize image components in a "UniversalImage" component that will render either SVGs, PNGs, JPEGS and even JPEG2000 images.