### PR TITLE
fix: force connection deletion on error

### DIFF
--- a/src/hooks/agent/actions/AgentActionExecuterMap.ts
+++ b/src/hooks/agent/actions/AgentActionExecuterMap.ts
@@ -361,18 +361,20 @@ export const AgentActionExecuterMap: Record<AgentActionType, ActionFactory> = {
         )
       }
 
+      let errorWhileDeleting: Error | undefined
       try {
         await options.agent.didcomm.connections.deleteById(connectionId)
       } catch (error) {
         logWarn(
           `Error deleting connection ${connectionId} directly. Forcing deletion before throwing 
-          for KeylistUpdate retrying`,
+          for KeylistUpdate retry process`,
         )
         const didCommConnectionService = options.agent.dependencyManager.resolve(DidCommConnectionService)
         const connection = await didCommConnectionService.findById(options.agent.context, connectionId)
         if (connection) {
           await didCommConnectionService.deleteById(options.agent.context, connectionId)
         }
+        errorWhileDeleting = error as Error
       }
 
       // Once the connection has been eliminated, delete its associated OOB record (only if we were invited
@@ -383,6 +385,11 @@ export const AgentActionExecuterMap: Record<AgentActionType, ActionFactory> = {
           await options.agent.didcomm.oob.deleteById(outOfBandRecordId)
         }
       }
+
+      if (errorWhileDeleting) {
+        throw errorWhileDeleting
+      }
+
       return { outgoingMessageType: DidCommKeylistUpdateMessage.type.messageTypeUri }
     }
   },

--- a/src/hooks/agent/actions/AgentActionExecuterMap.ts
+++ b/src/hooks/agent/actions/AgentActionExecuterMap.ts
@@ -25,7 +25,6 @@ import {
   DidCommProofStateChangedEvent,
   DidCommProofEventTypes,
   DidCommAutoAcceptProof,
-  DidCommHangupMessage,
   DidCommOutOfBandRole,
   DidCommFeaturesQueriesMessage,
   DidCommConnectionService,
@@ -63,6 +62,7 @@ import {
 } from './types'
 
 import { createOobInvitation, MobileAgent } from '@src/services/agent'
+import { logWarn } from '@src/utils'
 
 type AgentCallbackReturnType<T extends BaseRecord = BaseRecord> = {
   associatedRecord?: T
@@ -351,7 +351,30 @@ export const AgentActionExecuterMap: Record<AgentActionType, ActionFactory> = {
     return async (options: { agent: MobileAgent }) => {
       const parameters = action.parameters as DeleteConnectionParameters
       const { connectionId, outOfBandRecordId } = parameters
-      await options.agent.didcomm.connections.hangup({ connectionId, deleteAfterHangup: true })
+
+      try {
+        await options.agent.didcomm.connections.hangup({ connectionId, deleteAfterHangup: false })
+      } catch (error) {
+        logWarn(
+          `Error hanging up connection: ${error}. It will be deleted directly. No HangUp retry will be
+           performed.`,
+        )
+      }
+
+      try {
+        await options.agent.didcomm.connections.deleteById(connectionId)
+      } catch (error) {
+        logWarn(
+          `Error deleting connection ${connectionId} directly. Forcing deletion before throwing 
+          for KeylistUpdate retrying`,
+        )
+        const didCommConnectionService = options.agent.dependencyManager.resolve(DidCommConnectionService)
+        const connection = await didCommConnectionService.findById(options.agent.context, connectionId)
+        if (connection) {
+          await didCommConnectionService.deleteById(options.agent.context, connectionId)
+        }
+      }
+
       // Once the connection has been eliminated, delete its associated OOB record (only if we were invited
       // as the OOB record can be still valid for invitations we have created)
       if (outOfBandRecordId) {
@@ -360,7 +383,7 @@ export const AgentActionExecuterMap: Record<AgentActionType, ActionFactory> = {
           await options.agent.didcomm.oob.deleteById(outOfBandRecordId)
         }
       }
-      return { outgoingMessageType: DidCommHangupMessage.type.messageTypeUri }
+      return { outgoingMessageType: DidCommKeylistUpdateMessage.type.messageTypeUri }
     }
   },
 }

--- a/src/hooks/useSignUp.ts
+++ b/src/hooks/useSignUp.ts
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react'
 import Config from 'react-native-config'
 
 import { updateThreadFromServiceInfo } from './agent/chat/services'
+import { useConfig } from './providers/ConfigProvider'
 
 import { useMobileAgent, useUserProfile } from '@src/hooks/agent'
 import RealmSingleton from '@src/services/RealmSingleton'
@@ -12,16 +13,17 @@ import { saveInCacheServiceInfo } from '@src/services/agent/cache'
 import { getServiceInfo } from '@src/services/trustResolution'
 import { log, logError } from '@src/utils'
 
-const defaultServicePublicDid = Config.DEFAULT_SERVICE_PUBLIC_DID as string
-const defaultServiceAlias = Config.DEFAULT_SERVICE_ALIAS as string
-const cloudAgentPublicDid = Config.CLOUD_AGENT_PUBLIC_DID as string
-
 export const useSignUp = () => {
   const navigation = useNavigation()
   const { agent, handleChangeAgentState } = useMobileAgent()
   const { updateUserProfileData } = useUserProfile()
   const [displayName, setDisplayName] = useState('')
   const [displayPicture, setDisplayPicture] = useState<DidCommUserProfileData['displayPicture']>()
+
+  const { devEnvs } = useConfig()
+  const defaultServicePublicDid = Config.DEFAULT_SERVICE_PUBLIC_DID
+  const defaultServiceAlias = Config.DEFAULT_SERVICE_ALIAS
+  const cloudAgentPublicDid = devEnvs.CLOUD_AGENT_PUBLIC_DID
 
   const startSignUp = useCallback(async () => {
     if (!agent || !agent?.isInitialized) throw new Error('Agent not initialized')

--- a/src/pages/ConnectionDetails/BaseConnectionDetails.tsx
+++ b/src/pages/ConnectionDetails/BaseConnectionDetails.tsx
@@ -29,7 +29,6 @@ import {
   isTerminated,
   unblockConnection,
 } from '@src/utils/connectionUtils'
-import { log } from '@src/utils/log'
 import { markNewConnectionNotificationAsViewed } from '@src/utils/pushNotificationsUtils'
 import { screenHeight } from '@src/utils/responsiveUtils'
 import { toast } from '@src/utils/toast'
@@ -71,7 +70,6 @@ const BaseConnectionDetails = ({
   const [blockingConnection, setBlockingConnection] = useState(false)
   const modalConfirmationTypeRef = useRef<confirmationTypes>('deleteChat')
   const connectionName = getConnectionDisplayName(connection)
-  log(`connectionName: ${connectionName}`)
   const isConnectionCompleted = connection.isReady
   const isConnectionBlocked = isBlocked(connection)
   const isConnectionTerminated = isTerminated(connection)


### PR DESCRIPTION
Currently, when a connection is deleted, at least two messages are exchanged:

- Hangup to the other end (to inform about connection termination)
- Keylist Update to DIDComm mediator (to cleanup the keys associated to the connection)

If the Hangup fails (e.g. the other party is offline or they deleted us, which often happens when testing services), it will be retried a few times, but the key list update will not be executed and neither the connection deletion. Usually it is possible to delete it afterwards, by manually going to Connections menu. But in some test services, this doesn't work anymore. This is not the typical end-user use case, but developers might need to even delete their wallet to keep testing their services.

So here is a simple, maybe not ultimate, but sufficient for most cases at least until we move to DIDComm V2 and implement a more robust mechanism for agent messaging:

- If Hangup fails, it is not retried
- If Keylist Update fails, it will be retried up to 4 times. But the DIDComm connection record will be deleted immediately

