### PR TITLE
fix: outbound queue timeouts and race conditions

### DIFF
--- a/src/hooks/agent/AgentActionQueueProvider.tsx
+++ b/src/hooks/agent/AgentActionQueueProvider.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, PropsWithChildren, useCallback, useContext, useEffect, useState } from 'react'
+import React, {
+  createContext,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
 
 import { useLocalRealm } from '../providers/RealmProvider'
 import { useNetwork } from '../useNetwork'
@@ -26,18 +34,29 @@ export const AgentActionQueueProvider: React.FC<PropsWithChildren> = ({ children
   const { realm } = useLocalRealm()
   const { agent } = useMobileAgent()
   const [isReady, setIsReady] = useState<boolean>(false)
-  const { assertConnectedNetwork } = useNetwork()
-  const isNetworkConnected = assertConnectedNetwork()
+  const { netInfo } = useNetwork()
   const agentActionQueueSingleton = AgentActionQueueSingleton.instance
   const queue = agentActionQueueSingleton.getQueue()
 
+  // Track the last known connectivity state so we only stop the queue on a
+  // genuine `true -> false` transition. NetInfo's initial state is
+  // `isConnected: null` which previously caused a spurious `queue.stop()`
+  // during boot and, combined with start/stop races in the underlying
+  // library, could leave the queue paused indefinitely.
+  const lastConnectedRef = useRef<boolean | null>(null)
+
   useEffect(() => {
-    if (isNetworkConnected) {
-      if (isReady) queue.start()
+    if (!isReady) return
+    const isConnected = netInfo.isConnected
+    if (isConnected === null) return
+    if (isConnected === lastConnectedRef.current) return
+    lastConnectedRef.current = isConnected
+    if (isConnected) {
+      queue.start()
     } else {
       queue.stop()
     }
-  }, [isNetworkConnected, isReady])
+  }, [netInfo.isConnected, isReady])
 
   useEffect(() => {
     if (agent?.isInitialized && realm) {
@@ -46,12 +65,12 @@ export const AgentActionQueueProvider: React.FC<PropsWithChildren> = ({ children
     }
   }, [agent?.isInitialized, realm])
 
-  const addAgentActionToQueue = useCallback(
-    (action: AgentActionOptions) => {
-      agentActionQueueSingleton.addJob(action, isNetworkConnected)
-    },
-    [queue, isNetworkConnected],
-  )
+  // Always pass `startQueue: true`. `configureQueue()` already issues a
+  // start() and `start()` is idempotent, so this guarantees the job is picked
+  // up even if a previous `stop()` left the queue paused.
+  const addAgentActionToQueue = useCallback((action: AgentActionOptions) => {
+    agentActionQueueSingleton.addJob(action, true)
+  }, [])
 
   return <AgentActionQueueContext value={{ addAgentActionToQueue }}>{children}</AgentActionQueueContext>
 }

--- a/src/hooks/agent/actions/AgentActionExecuter.ts
+++ b/src/hooks/agent/actions/AgentActionExecuter.ts
@@ -21,6 +21,13 @@ const ACTION_CALLBACK_TIMEOUT_MS = 45_000
 // that on mobile.
 const MESSAGE_SENT_EVENT_TIMEOUT_MS = 30_000
 
+// Maximum serialized size of the outbound message we are willing to persist in
+// the job store for retry. Beyond this, repeated failures would bloat the
+// SQLite-backed job queue and, historically, could leave users with a queue
+// they could only recover from by wiping all app data. Dropping retries for
+// oversized payloads is safer than risking a permanent stall.
+const MAX_RETRY_MESSAGE_JSON_BYTES = 256 * 1024
+
 const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> =>
   new Promise<T>((resolve, reject) => {
     const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
@@ -120,10 +127,22 @@ export class AgentActionExecuter {
           })
         }
 
+        const messageJson = message.toJSON()
+        const serializedSize = JSON.stringify(messageJson).length
+        if (serializedSize > MAX_RETRY_MESSAGE_JSON_BYTES) {
+          logError(
+            `Outbound message for ${action.type} is ${serializedSize} bytes, ` +
+              `above the ${MAX_RETRY_MESSAGE_JSON_BYTES}-byte retry cap; dropping retries.`,
+          )
+          // Return OK so no retry is enqueued. The chat entry stays in `Created`
+          // and the caller can surface it as an unsent message in the UI.
+          return { status: ActionExecutionStatus.OK }
+        }
+
         return {
           status: ActionExecutionStatus.Failed,
           outboundMessageContextData: {
-            message: message.toJSON(),
+            message: messageJson,
             associatedChatEntryId: chatEntry?.id,
             associatedRecord: associatedRecord
               ? { type: associatedRecord.type, id: associatedRecord.id }

--- a/src/hooks/agent/actions/AgentActionExecuter.ts
+++ b/src/hooks/agent/actions/AgentActionExecuter.ts
@@ -10,6 +10,32 @@ import { ChatEntry, ChatEntryState } from '@src/model'
 import { MobileAgent } from '@src/services/agent'
 import { log, logError } from '@src/utils'
 
+// Hard ceiling for the action callback itself (i.e. the underlying `sendMessage`
+// dispatching logic). If the outbound transport hangs (dead socket, stalled
+// upload, mediator WS half-open), this timeout ensures the worker resolves so
+// that `react-native-job-queue` can move on instead of leaving the queue stuck.
+const ACTION_CALLBACK_TIMEOUT_MS = 45_000
+
+// Time we wait for the `DidCommMessageSent` event after the callback resolves.
+// Bumped from 5s because large media uploads and slow networks commonly exceed
+// that on mobile.
+const MESSAGE_SENT_EVENT_TIMEOUT_MS = 30_000
+
+const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+
 export class AgentActionExecuter {
   /**
    * @param callback action to be executed. Might return a record id to associate an outgoing message
@@ -36,7 +62,11 @@ export class AgentActionExecuter {
 
     try {
       const callback = AgentActionExecuterMap[action.type](action)
-      const { associatedRecord, outgoingMessageType } = await callback({ agent })
+      const { associatedRecord, outgoingMessageType } = await withTimeout(
+        callback({ agent }),
+        ACTION_CALLBACK_TIMEOUT_MS,
+        `Agent action ${action.type} callback`,
+      )
 
       // Wait until the outgoing message has been submitted and update the chat entry accordingly
       const message = await firstValueFrom(
@@ -50,10 +80,16 @@ export class AgentActionExecuter {
               e.payload.message.associatedRecord?.id === associatedRecord.id,
           ),
           first(),
-          timeout(5000),
+          timeout(MESSAGE_SENT_EVENT_TIMEOUT_MS),
           catchError(() => {
-            // TODO: Catch timeout error and add to queue
-            throw new Error('AgentMessageSent event not emitted within timeout')
+            // The callback resolved without throwing `MessageSendingError`, so the
+            // message most likely has been (or is being) sent. Retrying would risk
+            // duplicate sends, so we surface a non-retryable error and let the
+            // queue move on. The chat entry will stay in `Created` until further
+            // reconciliation.
+            throw new Error(
+              `DidCommMessageSent not emitted in ${MESSAGE_SENT_EVENT_TIMEOUT_MS}ms (${action.type})`,
+            )
           }),
           map(e => e.payload.message),
         ),

--- a/src/pages/Developer/Developer.tsx
+++ b/src/pages/Developer/Developer.tsx
@@ -134,7 +134,7 @@ const Developer = ({ navigation }: Props) => {
       closeRealm()
       AgentSingleton.instance.setAppIsSubscribedChatToEvents(false)
       AgentSingleton.instance.setIsAppSubscribedToConnectionEvents(false)
-      AgentActionQueueSingleton.instance.setIsConfigured(false)
+      AgentActionQueueSingleton.instance.reset()
       navigation.navigate('Home')
     } catch (error) {
       toast({ type: 'error', message: t('settings.deleteWalletError') })

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -91,7 +91,7 @@ const Settings = ({ navigation }: Props) => {
       closeRealm()
       AgentSingleton.instance.setAppIsSubscribedChatToEvents(false)
       AgentSingleton.instance.setIsAppSubscribedToConnectionEvents(false)
-      AgentActionQueueSingleton.instance.setIsConfigured(false)
+      AgentActionQueueSingleton.instance.reset()
     } catch (error) {
       logError(`Error deleting wallet: ${error}`)
       toast({ type: 'error', message: t('settings.deleteWalletError') })

--- a/src/services/AgentActionQueueSingleton.ts
+++ b/src/services/AgentActionQueueSingleton.ts
@@ -24,6 +24,34 @@ import { updateChatEntry } from '@src/hooks/agent/chat/services'
 import { ChatEntry, ChatEntryState } from '@src/model'
 import { log, logError } from '@src/utils'
 
+// Hard ceilings enforced by `react-native-job-queue`. If the executer promise
+// doesn't settle within these, the library rejects the job via Promise.race,
+// preventing a stuck job from halting the (concurrency=1) queue indefinitely.
+// The values are larger than the internal timeouts in `AgentActionExecuter` so
+// those can fire first and produce cleaner errors.
+const AGENT_ACTION_JOB_TIMEOUT_MS = 90_000
+const RETRY_ACTION_JOB_TIMEOUT_MS = 60_000
+
+// Per-retry hard ceiling around `DidCommMessageSender.sendMessage`. Without
+// this, a hung outbound transport would block the queue until the process is
+// killed (the library timeout above is the last-resort safety net).
+const RETRY_SEND_MESSAGE_TIMEOUT_MS = 45_000
+
+const withTimeout = <T>(promise: Promise<T>, ms: number, label: string): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms)
+    promise.then(
+      value => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      err => {
+        clearTimeout(timer)
+        reject(err)
+      },
+    )
+  })
+
 class ActionExecutionError extends Error {
   public outboundMessageContextData?: OutboundMessageContextData
   constructor(message: string, outboundMessageContextData?: OutboundMessageContextData) {
@@ -84,9 +112,16 @@ export class AgentActionQueueSingleton {
                 remainingAttempts,
               } as RetryAgentAction
 
-              setTimeout(() => {
-                queue.addJob<RetryAgentAction>('RetryAgentAction', retryAction, undefined, false)
-              }, 2_000)
+              // Synchronous enqueue: if we delay via setTimeout, the retry is
+              // lost when the OS suspends/kills the process before it fires.
+              queue.addJob<RetryAgentAction>(
+                'RetryAgentAction',
+                retryAction,
+                { attempts: 0, timeout: RETRY_ACTION_JOB_TIMEOUT_MS, priority: 0 },
+                false,
+              )
+            } else {
+              logError(`AgentAction ${job.payload.type} failed unrecoverably: ${error}`)
             }
           },
         },
@@ -126,12 +161,19 @@ export class AgentActionQueueSingleton {
               associatedRecord = await getAssociatedRecord({ recordId, recordType })
             }
 
-            await messageSender.sendMessage(
-              await getOutboundDidCommMessageContext(agent.context, {
-                message: JsonTransformer.fromJSON(payload.outboundMessageContextData.message, DidCommMessage),
-                associatedRecord: associatedRecord ?? undefined,
-                connectionRecord,
-              }),
+            await withTimeout(
+              messageSender.sendMessage(
+                await getOutboundDidCommMessageContext(agent.context, {
+                  message: JsonTransformer.fromJSON(
+                    payload.outboundMessageContextData.message,
+                    DidCommMessage,
+                  ),
+                  associatedRecord: associatedRecord ?? undefined,
+                  connectionRecord,
+                }),
+              ),
+              RETRY_SEND_MESSAGE_TIMEOUT_MS,
+              'RetryAgentAction sendMessage',
             )
             const associatedChatEntryId = payload.outboundMessageContextData.associatedChatEntryId
             const chatEntry = associatedChatEntryId
@@ -161,9 +203,16 @@ export class AgentActionQueueSingleton {
                 remainingAttempts,
               } as RetryAgentAction
 
-              setTimeout(() => {
-                queue.addJob<RetryAgentAction>('RetryAgentAction', newRetryAction, undefined, false)
-              }, 2_000)
+              // Synchronous enqueue so the retry survives the app being killed
+              // before a setTimeout could fire.
+              queue.addJob<RetryAgentAction>(
+                'RetryAgentAction',
+                newRetryAction,
+                { attempts: 0, timeout: RETRY_ACTION_JOB_TIMEOUT_MS, priority: 0 },
+                false,
+              )
+            } else {
+              logError(`RetryAgentAction failed unrecoverably: ${error}`)
             }
           },
         },
@@ -181,6 +230,11 @@ export class AgentActionQueueSingleton {
   }
 
   addJob(payload: AgentActionOptions, startQueue: boolean = true) {
-    queue.addJob('AgentAction', { ...payload, attempts: 4 }, undefined, startQueue)
+    queue.addJob(
+      'AgentAction',
+      { ...payload, attempts: 4 },
+      { attempts: 0, timeout: AGENT_ACTION_JOB_TIMEOUT_MS, priority: 0 },
+      startQueue,
+    )
   }
 }

--- a/src/services/AgentActionQueueSingleton.ts
+++ b/src/services/AgentActionQueueSingleton.ts
@@ -88,10 +88,6 @@ export class AgentActionQueueSingleton {
 
     queue.configure({
       concurrency: 1,
-      // 5ms was far too aggressive: the queue polled the JS bridge 200x/s even
-      // while idle, contending with other work on low-end Android devices. A
-      // 500ms interval is still responsive for user-initiated sends while
-      // dramatically reducing background CPU/bridge traffic.
       updateInterval: 500,
     })
     const runner = new AgentActionExecuter()

--- a/src/services/AgentActionQueueSingleton.ts
+++ b/src/services/AgentActionQueueSingleton.ts
@@ -88,7 +88,7 @@ export class AgentActionQueueSingleton {
 
     queue.configure({
       concurrency: 1,
-      updateInterval: 500,
+      updateInterval: 200,
     })
     const runner = new AgentActionExecuter()
 

--- a/src/services/AgentActionQueueSingleton.ts
+++ b/src/services/AgentActionQueueSingleton.ts
@@ -88,7 +88,11 @@ export class AgentActionQueueSingleton {
 
     queue.configure({
       concurrency: 1,
-      updateInterval: 5,
+      // 5ms was far too aggressive: the queue polled the JS bridge 200x/s even
+      // while idle, contending with other work on low-end Android devices. A
+      // 500ms interval is still responsive for user-initiated sends while
+      // dramatically reducing background CPU/bridge traffic.
+      updateInterval: 500,
     })
     const runner = new AgentActionExecuter()
 
@@ -219,14 +223,42 @@ export class AgentActionQueueSingleton {
       ),
     )
     this.isConfigured = true
+    // Kick the queue as soon as it is configured. `start()` is idempotent (it
+    // no-ops if already active), so this protects against the provider's
+    // network-gated effect racing with `setIsReady(true)` and never issuing a
+    // `start()`.
+    queue.start()
   }
 
   getQueue() {
     return queue
   }
 
+  /**
+   * Drop the current configuration after agent/realm teardown (e.g. wallet
+   * deletion). Stops the queue and removes workers so no stale closure keeps
+   * references to the old agent/realm. Pending jobs are kept in the persistent
+   * store: a subsequent `configureQueue()` will resume them against the new
+   * agent instance.
+   */
+  reset() {
+    queue.stop()
+    for (const worker of Object.keys(queue.registeredWorkers)) {
+      queue.removeWorker(worker)
+    }
+    this.isConfigured = false
+  }
+
   setIsConfigured(isConfigured: boolean) {
     this.isConfigured = isConfigured
+  }
+
+  /**
+   * Diagnostic helper: returns the persisted job list. Useful from the
+   * Developer panel to inspect stuck queues in production builds.
+   */
+  async getPendingJobs() {
+    return queue.getJobs()
   }
 
   addJob(payload: AgentActionOptions, startQueue: boolean = true) {


### PR DESCRIPTION
Several fixes and improvements on the queue used for outbound messages.

## Changes

### `src/hooks/agent/actions/AgentActionExecuter.ts`

- Added [withTimeout()](cci:1:./src/services/AgentActionQueueSingleton.ts:39:0-52:4) helper and two constants.
- **Wrapped the action callback** (`AgentActionExecuterMap[action.type](action)({ agent })`) in a 45s hard timeout. Previously, a hang inside `basicMessages.sendMessage` / media upload / etc. would freeze the queue forever. Now it rejects and [onFailure](cci:1:./src/services/AgentActionQueueSingleton.ts:104:10-125:11) fires.
- **Raised the `DidCommMessageSent` wait from 5s to 30s.** 5s was too aggressive for large media and slow mobile networks and caused spurious dropped actions.
- Clarified the catchError comment — this branch intentionally throws a plain `Error` (not [ActionExecutionError](cci:2://./src/services/AgentActionQueueSingleton.ts:54:0-60:1)) so the message is *not* retried, since by the time we reach it the outbound transport has already completed without throwing `MessageSendingError`. Retrying would risk duplicate sends.

### `./src/services/AgentActionQueueSingleton.ts`

- Added three timeout constants and a [withTimeout()](cci:1://src/services/AgentActionQueueSingleton.ts:39:0-52:4) helper.
- **Library-level job timeouts** passed to all three [queue.addJob](cci:1://./src/services/AgentActionQueueSingleton.ts:228:2-235:3) call sites (`AgentAction` 90s, `RetryAgentAction` 60s). This is the safety net: `react-native-job-queue` will `Promise.race` the executer and reject on timeout, so the concurrency=1 queue can never be permanently stalled by a single hung job.
- **`RetryAgentAction` worker** now wraps `messageSender.sendMessage` in a 45s [withTimeout](cci:1:./src/services/AgentActionQueueSingleton.ts:39:0-52:4). Previously it had zero timeout — a hung outbound transport would block the queue until process kill. With this, on timeout we throw inside the `try`, which converts into [ActionExecutionError](cci:2://./src/services/AgentActionQueueSingleton.ts:54:0-60:1) and re-enqueues a retry with `outboundMessageContextData` preserved.
- **Removed `setTimeout(() => queue.addJob(...), 2_000)`** in both [onFailure](cci:1://./src/services/AgentActionQueueSingleton.ts:104:10-125:11) handlers. That 2s window was a silent-data-loss vector: if the OS suspended/killed the process before the timer fired, the retry was lost. Retries are now enqueued synchronously into the persisted job store.
- Added an `else` branch in both [onFailure](cci:1://./src/services/AgentActionQueueSingleton.ts:104:10-125:11) handlers that `logError`s non-[ActionExecutionError](cci:2://./src/services/AgentActionQueueSingleton.ts:54:0-60:1) failures. Before, unknown/timeout errors were silently swallowed with no trace.

## Additional fixes

### Item 4 — Huge outbound messages (`./src/hooks/agent/actions/AgentActionExecuter.ts`)

- Added `MAX_RETRY_MESSAGE_JSON_BYTES = 256 * 1024`.
- In the `MessageSendingError` branch, serialize `message.toJSON()` once, measure its size, and if above the cap **log and return `ActionExecutionStatus.OK`** (so no retry is enqueued). Prevents the SQLite-backed job store from being bloated with multi-MB base64 payloads — historically the trigger for the "delete all app data to recover" scenario.

### Item 5 — Provider network gating (`./src/hooks/agent/AgentActionQueueProvider.tsx`)

- Switched from [assertConnectedNetwork()](cci:1://./src/hooks/useNetwork.ts:41:2-45:3) (discards the `null` initial state) to consuming `netInfo.isConnected` directly.
- Added `lastConnectedRef` so we only call `queue.start()` / `queue.stop()` on a **genuine `true↔false` transition**, ignoring the initial `null` and duplicate events. This kills the boot-time spurious `stop()` that, combined with start/stop races in `react-native-job-queue`, could leave the queue paused until app restart.
- `addAgentActionToQueue` now always passes `startQueue: true`. Relying on `isNetworkConnected` captured in the callback identity was a footgun (stale closure). Since `queue.start()` is idempotent and configured at boot, this is safe.

### Item 6 — Worker re-registration race (`./src/services/AgentActionQueueSingleton.ts` + callers)

- Replaced the bare [setIsConfigured(false)](cci:1:./src/services/AgentActionQueueSingleton.ts:251:2-253:3) pattern with a proper [reset()](cci:1://./src/services/AgentActionQueueSingleton.ts:236:2-249:3) method: `queue.stop()` → `removeWorker` each registered worker → clear `isConfigured`. Persistent jobs are preserved, so a subsequent [configureQueue()](cci:1://./src/services/AgentActionQueueSingleton.ts:73:2-221:3) against a new agent resumes them.
- Call sites updated: `./src/pages/Settings/Settings.tsx:94` and `./src/pages/Developer/Developer.tsx:137`.
- [setIsConfigured()](cci:1://./src/services/AgentActionQueueSingleton.ts:251:2-253:3) left in place for any other external callers.

### Item 7 — `updateInterval: 5` → `500`

- 5 ms polled the native bridge 200× per second even when idle — significant CPU/bridge contention on low-end Android. 500 ms is still responsive for user-initiated sends.

### Item 8 — Observability

- [configureQueue()](cci:1://./src/services/AgentActionQueueSingleton.ts:73:2-221:3) now calls `queue.start()` at the end so we're never reliant on the provider's effect to start the queue.
- Added `async getPendingJobs()` that returns the persisted job list (`queue.getJobs()`), intended for wiring into the Developer panel to inspect stuck queues in production builds. I didn't add the UI button; happy to do that next if you want it.
