### PR TITLE
fix: support eID PACE authentication

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -13,7 +13,7 @@ end
 node_require('react-native/scripts/react_native_pods.rb')
 node_require('react-native-permissions/scripts/setup.rb')
 
-platform :ios, '15.6'
+platform :ios, '16.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 linkage = ENV['USE_FRAMEWORKS']

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2374,7 +2374,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - react-native-eid-reader (0.2.0):
+  - react-native-eid-reader (0.3.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -4650,7 +4650,7 @@ SPEC CHECKSUMS:
   react-native-config: 2249b7e68644c86ea68358f5a0d746d1c648f900
   react-native-create-thumbnail: c15cedc37f3822777d44e6035be041f7961341ea
   react-native-date-picker: 9e761de1a6b100b2f61669de1f2c3e5717e2b525
-  react-native-eid-reader: 5add1bee43af9bdf14f050b61bc927406ab63572
+  react-native-eid-reader: ae26fb01de847d4fbed503c49608a7004f31480c
   react-native-get-random-values: e2acf4070fe4b7325705a05af047449637a27a21
   react-native-image-resizer: 290b045c34c69db7574e4d08aadfc4abe1ff5a99
   react-native-job-queue: cfd8b0a4e23743b702efedf109f64692250c1dc3
@@ -4724,6 +4724,6 @@ SPEC CHECKSUMS:
   VisionCamera: 0044a94f7489f19e19d5938e97dfc36f4784af3c
   Yoga: cf2a67aa1c8a225f0cb98a5f531d6f305d3f12e5
 
-PODFILE CHECKSUM: 33b1bdf40ac5d36c6dfdd0f9a0f5a8f3ed2dbc03
+PODFILE CHECKSUM: 68ada27e04592dfe1963faa9d953030c2f0a1ab7
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "react-native-config": "1.6.1",
     "react-native-create-thumbnail": "2.2.0",
     "react-native-date-picker": "5.0.12",
-    "react-native-eid-reader": "npm:@2060.io/react-native-eid-reader@0.2.0",
+    "react-native-eid-reader": "npm:@2060.io/react-native-eid-reader@0.3.0",
     "react-native-file-logger": "0.7.2",
     "react-native-gesture-handler": "2.28.0",
     "react-native-get-random-values": "~2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,8 +223,8 @@ importers:
         specifier: 5.0.12
         version: 5.0.12(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)
       react-native-eid-reader:
-        specifier: npm:@2060.io/react-native-eid-reader@0.2.0
-        version: '@2060.io/react-native-eid-reader@0.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)'
+        specifier: npm:@2060.io/react-native-eid-reader@0.3.0
+        version: '@2060.io/react-native-eid-reader@0.3.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)'
       react-native-file-logger:
         specifier: 0.7.2
         version: 0.7.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)
@@ -478,8 +478,8 @@ packages:
       '@credo-ts/core': 0.7.0-alpha-20260423133702
       '@credo-ts/didcomm': 0.7.0-alpha-20260423133702
 
-  '@2060.io/react-native-eid-reader@0.2.0':
-    resolution: {integrity: sha512-8ql1OWuhBW3Cs3SDppYQ3JFzYlTKiFVHFlVZicl9BXrncg7TqC/pBprglQ/+s4MUzPdgrBVkVLsEf3zKtgCrhA==}
+  '@2060.io/react-native-eid-reader@0.3.0':
+    resolution: {integrity: sha512-L+/+7gxsaBdqWpphInK3RW16TQ2AFxu5lFusSKgB7wQgU59lOPwaD527Ty0KnEx5vv+O3y9TCZ9zCd9C22K1Wg==}
     peerDependencies:
       react: 19.1.1
       react-native: '*'
@@ -8515,7 +8515,7 @@ snapshots:
       rxjs: 7.8.2
       tsyringe: 4.10.0
 
-  '@2060.io/react-native-eid-reader@0.2.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)':
+  '@2060.io/react-native-eid-reader@0.3.0(react-native@0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10))(react@19.1.1)':
     dependencies:
       react: 19.1.1
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native-community/cli@20.0.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))(@react-native/metro-config@0.83.6(@babel/core@7.29.0)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.1.17)(bufferutil@4.0.9)(react@19.1.1)(utf-8-validate@5.0.10)


### PR DESCRIPTION
Note that this means that the app will need iOS 16 to work. Should not represent any major issue, since all devices since iPhone 8 (2017) are supported.

We are dropping support for 10+ year old devices such as iPhone 7 and iPhone SE (1st generation).