### PR TITLE
feat(scan): handle public DID input as implicit invitation

### DIFF
--- a/src/pages/Scan/Scan.tsx
+++ b/src/pages/Scan/Scan.tsx
@@ -23,7 +23,12 @@ import { TextInput, Text, MainButton, ModalLoading } from '@src/components/commo
 import { useAppState } from '@src/hooks'
 import { useMobileAgent } from '@src/hooks/agent'
 import { useTheme } from '@src/hooks/providers/ThemeProvider'
-import { DidcommInvitationType, getOutOfBandRecordById, processInvitation } from '@src/services/agent/oob'
+import {
+  DidcommInvitationType,
+  getOutOfBandRecordById,
+  processImplicitInvitation,
+  processInvitation,
+} from '@src/services/agent/oob'
 import { log, logError } from '@src/utils'
 import { toast } from '@src/utils/toast'
 
@@ -85,32 +90,45 @@ const Scan = ({ navigation }: Props) => {
     }
   }
 
+  const processImplicitDidInvitation = async (did: string) => {
+    if (!agent) return
+    try {
+      setProcessing(true)
+      const result = await processImplicitInvitation(agent, did)
+      log('processImplicitInvitationResult:', result)
+      if (!result.success) throw new Error(result.error)
+      const outOfBandRecord = await getOutOfBandRecordById(agent, result.recordId)
+      navigation.navigate('ConnectionInvitation', {
+        outOfBandRecord,
+        existingConnectionId: result.existingConnectionId,
+      })
+    } catch (error) {
+      setIsActiveCamera(true)
+      toast({ type: 'error', message: t('invitation.errorProcessingInvitation'), duration: 5000 })
+      logError(`Error processing Didcomm Invitation: ${error}`)
+    } finally {
+      setProcessing(false)
+    }
+  }
+
   const onCodeScanned = async (rawUrl: string) => {
     if (!agent) return
     try {
       setIsActiveCamera(false)
 
       const url = rawUrl.trim()
-      let invitation: DidCommOutOfBandInvitation | undefined
       if (url.startsWith('did:')) {
-        // FIXME: this should be based on both Hologram and other party supported protocols
-        invitation = new DidCommOutOfBandInvitation({
-          id: url,
-          label: 'DID Invitation',
-          services: [url],
-          handshakeProtocols: ['https://didcomm.org/didexchange/1.1'],
-        })
-        invitation.setThread({ parentThreadId: url })
+        await processImplicitDidInvitation(url)
       } else {
         const parsedUrl = queryString.parseUrl(url)
         const shortUrl =
           ((parsedUrl.query.oobUrl as string | undefined) ?? (parsedUrl.query._url as string | undefined))
             ? TypedArrayEncoder.toUtf8String(TypedArrayEncoder.fromBase64(parsedUrl.query._url as string))
             : undefined
-        invitation = await agent.didcomm.oob.parseInvitation(shortUrl ?? url)
+        const invitation = await agent.didcomm.oob.parseInvitation(shortUrl ?? url)
+        await processDidcommInvitation(invitation)
       }
 
-      await processDidcommInvitation(invitation)
       setScannedCode('')
     } catch (error) {
       setIsActiveCamera(true)

--- a/src/services/agent/oob/index.ts
+++ b/src/services/agent/oob/index.ts
@@ -34,7 +34,7 @@ import { getInCacheServiceInfo } from '../cache'
 
 import { OutOfBandInvitationEvent, OutOfBandInvitationEventTypes } from './OutOfBandEvents'
 
-import { log, logError } from '@src/utils'
+import { log, logError, logWarn } from '@src/utils'
 import { deletePendingConnection, findExistingConnection, isService } from '@src/utils/connectionUtils'
 import { toast } from '@src/utils/toast'
 
@@ -119,6 +119,57 @@ type ProcessInvitationResult =
       success: false
       error: string
     }
+/**
+ * Process an implicit OOB invitation expressed as a public DID. Delegates to Credo's
+ * receiveImplicitInvitation, which resolves the DID Doc and picks the highest mutually
+ * supported DIDComm version (v2 if both sides support it, otherwise v1). Used when the
+ * scanned input is a bare `did:` URI rather than a full OOB invitation.
+ */
+export const processImplicitInvitation = async (
+  agent: MobileAgent,
+  did: string,
+): Promise<ProcessInvitationResult> => {
+  try {
+    const connectionsApi = agent.context.dependencyManager.resolve(DidCommConnectionsApi)
+    const existingConnections = await connectionsApi.findByInvitationDid(did)
+    if (existingConnections.length > 1) {
+      logWarn(`Multiple connections found related to invitation DID ${did}`)
+    }
+    const existingConnection = existingConnections[0]
+
+    if (existingConnection?.outOfBandId) {
+      const existingOobRecord = await agent.didcomm.oob.findById(existingConnection.outOfBandId)
+      if (existingOobRecord) {
+        return {
+          success: true,
+          invitationType: DidcommInvitationType.ConnectionRequest,
+          existingConnectionId: existingConnection.id,
+          recordId: existingOobRecord.id,
+        }
+      }
+    }
+
+    const { outOfBandRecord } = await agent.didcomm.oob.receiveImplicitInvitation({
+      did,
+      label: 'DID Invitation',
+      autoAcceptInvitation: false,
+      autoAcceptConnection: false,
+    })
+
+    return {
+      success: true,
+      invitationType: DidcommInvitationType.ConnectionRequest,
+      existingConnectionId: existingConnection?.id,
+      recordId: outOfBandRecord.id,
+    }
+  } catch (error) {
+    return {
+      success: false,
+      error: (error as Error).message,
+    }
+  }
+}
+
 /**
  * Process a DIDComm invitation by assigning an out of band record to it. In case of regular connection
  * invitations, it will return specifying if there was already a connection associated to it.


### PR DESCRIPTION
## Summary
- Replace artificial v1 OOB-invitation construction in `Scan.tsx` with a call to `agent.didcomm.oob.receiveImplicitInvitation`.
- Credo-ts now picks v1 or v2 based on the resolved DID Doc and the agent's enabled protocols.

Closes #480

## Test plan
- [ ] Scan a public DID resolving to a v1-only service. Verify connection completes via DID Exchange.
- [ ] Scan a public DID resolving to a v2 service. Verify connection completes via v2.
- [ ] Re-scan a DID with an existing connection. Verify the existing OOB record is reused.

> Stacked on #478. Targets the bump branch so the V2 envelope changes are available; will auto-retarget to `main` when the parent merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)