### PR TITLE
fix: decode invitation short-link _url as base64url

### DIFF
--- a/src/pages/HomeMain/HomeMainContainer.tsx
+++ b/src/pages/HomeMain/HomeMainContainer.tsx
@@ -40,7 +40,7 @@ const HomeMainContainer = (HomeMainComponent: ElementType) => {
           if (parameterType === 'oobUrl') invitationUrl = urlValue
           else if (parameterType === '_url') {
             invitationUrl = urlValue
-              ? TypedArrayEncoder.toUtf8String(TypedArrayEncoder.fromBase64(urlValue))
+              ? TypedArrayEncoder.toUtf8String(TypedArrayEncoder.fromBase64Url(urlValue))
               : undefined
           } else invitationUrl = `${Config.BASE_INVITATION_URL}?${parameterType}=${urlValue}`
           if (!invitationUrl) throw new Error('Invalid invitation URL')

--- a/src/pages/Scan/Scan.tsx
+++ b/src/pages/Scan/Scan.tsx
@@ -119,10 +119,11 @@ const Scan = ({ navigation }: Props) => {
         await processImplicitDidInvitation(url)
       } else {
         const parsedUrl = queryString.parseUrl(url)
-        const shortUrl =
-          ((parsedUrl.query.oobUrl as string | undefined) ?? (parsedUrl.query._url as string | undefined))
-            ? TypedArrayEncoder.toUtf8String(TypedArrayEncoder.fromBase64(parsedUrl.query._url as string))
-            : undefined
+        const oobUrl = parsedUrl.query.oobUrl as string | undefined
+        const encodedUrl = parsedUrl.query._url as string | undefined
+        const shortUrl = encodedUrl
+          ? TypedArrayEncoder.toUtf8String(TypedArrayEncoder.fromBase64Url(encodedUrl))
+          : oobUrl
         const invitation = await agent.didcomm.oob.parseInvitation(shortUrl ?? url)
         await processDidcommInvitation(invitation)
       }


### PR DESCRIPTION
Closes #494 

We were incorrectly using `TypedArrayEncoder.fromBase64` instead of the 0.7.x's styled `TypedArrayEncoder.fromBase64Url`. 

Tested and verified.